### PR TITLE
Fix loading overlay visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
       box-shadow: 0 8px 40px rgba(0,0,0,.4);
     }
   
-  /* Show spinner while HTMX request is active */
-  #scan-spinner.htmx-request { display:block !important; }
+  /* Show spinner overlay while HTMX request is active */
+  #scan-overlay.htmx-request { display:grid !important; }
   /* optional: dim the results area while loading */
   .htmx-request #scan-results { opacity:.4; filter:grayscale(30%); }
 


### PR DESCRIPTION
## Summary
- Show scan overlay while HTMX requests run by targeting `#scan-overlay`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be247cb4888329a94c90d058ce8415