### PR TITLE
Add pytest framework and core tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Petra-Stock
+
+## Running Tests
+
+This project uses `pytest` for its test suite. After installing the project's
+dependencies, run the tests from the repository root:
+
+```bash
+pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,84 @@
+import sys, types, datetime, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Stub pandas
+pandas_stub = types.ModuleType('pandas')
+sys.modules.setdefault('pandas', pandas_stub)
+
+# Stub pandas_market_calendars
+pmc_stub = types.ModuleType('pandas_market_calendars')
+class DummyCalendar:
+    tz = datetime.timezone.utc
+pmc_stub.get_calendar = lambda name: DummyCalendar()
+sys.modules.setdefault('pandas_market_calendars', pmc_stub)
+
+# Stub FastAPI and related components
+fastapi_stub = types.ModuleType('fastapi')
+class FastAPI:
+    def __init__(self, *a, **kw):
+        pass
+    def mount(self, *a, **kw):
+        pass
+    def get(self, *a, **kw):
+        def decorator(fn):
+            return fn
+        return decorator
+    def post(self, *a, **kw):
+        def decorator(fn):
+            return fn
+        return decorator
+    def on_event(self, *a, **kw):
+        def decorator(fn):
+            return fn
+        return decorator
+fastapi_stub.FastAPI = FastAPI
+class Request:
+    pass
+fastapi_stub.Request = Request
+def Form(*a, **kw):
+    return None
+fastapi_stub.Form = Form
+def Depends(dep):
+    return dep
+fastapi_stub.Depends = Depends
+sys.modules.setdefault('fastapi', fastapi_stub)
+
+responses_stub = types.ModuleType('fastapi.responses')
+class HTMLResponse(dict):
+    def __init__(self, content='', status_code=200):
+        super().__init__(content=content)
+        self.status_code = status_code
+class RedirectResponse(dict):
+    def __init__(self, url='', status_code=307):
+        super().__init__(url=url)
+        self.status_code = status_code
+class JSONResponse(dict):
+    def __init__(self, content=None, status_code=200):
+        if content is None:
+            content = {}
+        super().__init__(content)
+        self.status_code = status_code
+responses_stub.HTMLResponse = HTMLResponse
+responses_stub.RedirectResponse = RedirectResponse
+responses_stub.JSONResponse = JSONResponse
+sys.modules.setdefault('fastapi.responses', responses_stub)
+
+static_stub = types.ModuleType('fastapi.staticfiles')
+class StaticFiles:
+    def __init__(self, directory, name=None):
+        self.directory = directory
+static_stub.StaticFiles = StaticFiles
+sys.modules.setdefault('fastapi.staticfiles', static_stub)
+
+templates_stub = types.ModuleType('fastapi.templating')
+class Jinja2Templates:
+    def __init__(self, directory):
+        self.directory = directory
+    def TemplateResponse(self, request, template_name, context):
+        return {'template': template_name, **context}
+templates_stub.Jinja2Templates = Jinja2Templates
+sys.modules.setdefault('fastapi.templating', templates_stub)
+
+# Stub pattern_finder_app to avoid heavy imports
+auto_stub = types.ModuleType('pattern_finder_app')
+sys.modules.setdefault('pattern_finder_app', auto_stub)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,11 @@
+import app
+
+
+def test_home_endpoint():
+    resp = app.home(request=None)
+    assert resp["template"] == "index.html"
+
+
+def test_scanner_page_endpoint():
+    resp = app.scanner_page(request=None)
+    assert resp["template"] == "index.html"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,23 @@
+import sqlite3
+import app
+
+
+def _prepare_db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    for stmt in app.SCHEMA[:2]:
+        cur.executescript(stmt)
+    return conn, cur
+
+
+def test_get_and_set_settings():
+    conn, cur = _prepare_db()
+    row = app.get_settings(cur)
+    assert row["id"] == 1
+
+    boundary = "2024-01-01T00:00:00"
+    app.set_last_run(boundary, cur)
+    cur.execute("SELECT last_boundary FROM settings WHERE id=1")
+    assert cur.fetchone()[0] == boundary
+    conn.close()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,16 @@
+import app
+
+
+def test_compute_scan_for_ticker_selects_best(monkeypatch):
+    def fake_scan(ticker, params):
+        if params["direction"] == "UP":
+            return {"ticker": ticker, "direction": "UP", "avg_roi_pct": 1,
+                    "hit_pct": 60, "support": 5, "stability": 1}
+        return {"ticker": ticker, "direction": "DOWN", "avg_roi_pct": 2,
+                "hit_pct": 70, "support": 10, "stability": 2}
+
+    monkeypatch.setattr(app, "_desktop_like_single", fake_scan)
+    params = {"direction": "BOTH"}
+    result = app.compute_scan_for_ticker("ABC", params)
+    assert result["direction"] == "DOWN"
+    assert result["avg_roi_pct"] == 2


### PR DESCRIPTION
## Summary
- introduce pytest-based testing with stubbed dependencies
- cover database helpers, API endpoints, and scanning logic
- document how to run the test suite

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be2cd805788329af323d3b1ca4dec5