### PR TITLE
Fix missing htmx by loading from CDN

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Pattern Finder — Scanner</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script src="/static/htmx.min.js" defer></script>
+  <script src="https://unpkg.com/htmx.org@1.9.9/dist/htmx.min.js" defer></script>
   <script src="/static/js/scanner.js" defer></script>
   <style>
     :root { --card:#0e1116; --ink:#e8eefc; --muted:#99a3b3; --accent:#5ea0ff; --line:#1a2337; }


### PR DESCRIPTION
## Summary
- Load htmx library from unpkg CDN to avoid missing local static file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be3931caec832989608dd2e59c2d53