### PR TITLE
Fix missing request in results template context

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -100,6 +100,7 @@ def results_from_archive(request: Request, run_id: int, db=Depends(get_db)):
     return templates.TemplateResponse(
         "results.html",
         {
+            "request": request,
             "rows": rows,
             "scan_type": run["scan_type"],
             "universe_count": len((run["universe"] or "").split(",")) if run["universe"] else 0,


### PR DESCRIPTION
## Summary
- Pass request to `results.html` TemplateResponse to prevent server error when viewing archived results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be3a70d8a483298b6117158b29b00e