### PR TITLE
style: improve results table spacing

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -78,6 +78,14 @@
     background: #111; color: #eee; border: 1px solid #333; border-radius: 10px;
     padding: 10px 14px; font-size: 14px; box-shadow: 0 8px 28px rgba(0,0,0,.25);
   }
+  .table { width:100%; border-collapse:collapse; }
+  .table th, .table td {
+    padding:.6rem .8rem;
+    border-bottom:1px solid var(--line, #1a2337);
+    vertical-align:top;
+  }
+  .table th { text-align:left; color:#b9c7de; }
+  .table tbody tr:hover { background:#111726; }
   .row-hover { cursor: context-menu; }
   .rule-td { max-width: 480px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .linklike { border: 0; background: transparent; color: #7fb3ff; cursor: pointer; }


### PR DESCRIPTION
## Summary
- add table styling so results rows are padded and highlight on hover

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be3cafbee48329beadcdfd54010df3