### PR TITLE
Add favorites deletion and display metrics

### DIFF
--- a/templates/favorites.html
+++ b/templates/favorites.html
@@ -42,6 +42,7 @@
             <th>Hit%</th>
             <th>DD%</th>
             <th>Rule</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -55,6 +56,11 @@
             <td>{{ '{:.1f}'.format(f['hit_pct']) if f['hit_pct'] is not none else '' }}</td>
             <td>{{ '{:.2f}'.format(f['avg_dd_pct']) if f['avg_dd_pct'] is not none else '' }}</td>
             <td><code>{{ f["rule"] }}</code></td>
+            <td>
+              <form method="post" action="/favorites/delete/{{ f['id'] }}" style="margin:0;">
+                <button type="submit" style="background:none;border:none;color:var(--muted);cursor:pointer;">&#10005;</button>
+              </form>
+            </td>
           </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- Show ROI, hit %, and drawdown in the Favorites list by fetching archived stats or recomputing them when missing
- Allow removing favorites via new `/favorites/delete/{id}` route and delete button in the Favorites table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be49292a488329bb9d663a18c9ffe1