### PR TITLE
Refactor templates for unified styling and layout

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -76,12 +76,12 @@ def _send_email(st: sqlite3.Row, subject: str, body: str, html_body: Optional[st
 
 @router.get("/", response_class=HTMLResponse)
 def home(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse("index.html", {"request": request, "active_tab": "scanner"})
 
 
 @router.get("/scanner", response_class=HTMLResponse)
 def scanner_page(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse("index.html", {"request": request, "active_tab": "scanner"})
 
 
 @router.get("/results/{run_id}", response_class=HTMLResponse)
@@ -100,13 +100,14 @@ def results_from_archive(request: Request, run_id: int, db=Depends(get_db)):
     rows.sort(key=lambda r: (r["avg_roi_pct"], r["hit_pct"], r["support"], r["stability"]), reverse=True)
 
     return templates.TemplateResponse(
-        "results.html",
+        "results_page.html",
         {
             "request": request,
             "rows": rows,
             "scan_type": run["scan_type"],
             "universe_count": len((run["universe"] or "").split(",")) if run["universe"] else 0,
             "run_id": run_id,
+            "active_tab": "archive",
         },
     )
 
@@ -168,7 +169,7 @@ def favorites_page(request: Request, db=Depends(get_db)):
             f["avg_roi_pct"] = None
             f["hit_pct"] = None
             f["avg_dd_pct"] = None
-    return templates.TemplateResponse(request, "favorites.html", {"favorites": favs})
+    return templates.TemplateResponse("favorites.html", {"request": request, "favorites": favs, "active_tab": "favorites"})
 
 
 @router.post("/favorites/delete/{fav_id}")
@@ -200,7 +201,7 @@ async def favorites_add(request: Request, db=Depends(get_db)):
 def archive_page(request: Request, db=Depends(get_db)):
     db.execute("SELECT id, started_at, scan_type, universe, finished_at, hit_count FROM runs ORDER BY id DESC LIMIT 200")
     runs = db.fetchall()
-    return templates.TemplateResponse(request, "archive.html", {"runs": runs})
+    return templates.TemplateResponse("archive.html", {"request": request, "runs": runs, "active_tab": "archive"})
 
 
 @router.post("/archive/save")
@@ -259,7 +260,7 @@ async def archive_save(request: Request, db=Depends(get_db)):
 @router.get("/settings", response_class=HTMLResponse)
 def settings_page(request: Request, db=Depends(get_db)):
     st = get_settings(db)
-    return templates.TemplateResponse(request, "settings.html", {"st": st})
+    return templates.TemplateResponse("settings.html", {"request": request, "st": st, "active_tab": "settings"})
 
 
 @router.post("/settings/save")

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,193 @@
+:root {
+  --card:#0e1116;
+  --ink:#e8eefc;
+  --muted:#99a3b3;
+  --accent:#5ea0ff;
+  --line:#1a2337;
+}
+
+html { font-size: clamp(16px,1.2vw + 0.5rem,22px); }
+
+body {
+  margin:0;
+  background:#0b0e14;
+  color:var(--ink);
+  font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif;
+}
+
+.wrap {
+  max-width:1400px;
+  margin:0 auto;
+  padding:clamp(16px,2vw,28px);
+}
+
+.tabs { display:flex; gap:.75rem; flex-wrap:wrap; margin-bottom:1rem; }
+
+.tab {
+  text-decoration:none;
+  color:var(--ink);
+  padding:.6rem .9rem;
+  border-radius:.8rem;
+  background:#111726;
+  border:1px solid var(--line);
+}
+
+.tab.active {
+  background:linear-gradient(180deg,#16243b,#122033);
+  border-color:#2a3a5d;
+  box-shadow:0 6px 20px #000 inset,0 1px 0 #2a3a5d;
+}
+
+.card {
+  background:var(--card);
+  border:1px solid var(--line);
+  border-radius:1rem;
+  padding:1rem;
+  box-shadow:0 20px 60px rgba(0,0,0,.35);
+}
+
+.grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:1rem; }
+
+label { display:block; color:var(--muted); margin-bottom:.35rem; }
+
+input, select {
+  width:100%;
+  padding:.7rem .8rem;
+  border-radius:.7rem;
+  border:1px solid var(--line);
+  background:#0c1220;
+  color:var(--ink);
+  font-size:1.1rem;
+}
+
+.row {
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+  gap:1rem;
+  margin-top:.5rem;
+}
+
+.actions {
+  display:flex;
+  gap:.7rem;
+  flex-wrap:wrap;
+  margin-top:1rem;
+  align-items:center;
+}
+
+button, .btn {
+  cursor:pointer;
+  background:var(--accent);
+  border:none;
+  color:#07101e;
+  font-weight:700;
+  padding:.8rem 1.1rem;
+  border-radius:.8rem;
+}
+
+.btn {
+  display:inline-block;
+  background:#161616;
+  border:1px solid #2b2b2b;
+  color:var(--ink);
+  padding:6px 10px;
+  font-weight:400;
+}
+
+.btn:hover { background:#1e1e1e; }
+
+.note, .muted { color:var(--muted); font-size:.95rem; }
+
+.results-card { margin-top:1.2rem; border-radius:1rem; border:1px solid #223056; box-shadow: inset 0 0 0 1px #0b1020, 0 20px 60px rgba(0,0,0,.3); padding:1rem; }
+
+.table {
+  width:100%;
+  border-collapse:collapse;
+}
+
+.table th, .table td {
+  padding:.6rem .8rem;
+  border-bottom:1px solid var(--line);
+  vertical-align:top;
+}
+
+.table th { text-align:left; color:#b9c7de; }
+
+.table tbody tr:hover { background:#111726; }
+
+.row-hover { cursor:pointer; }
+
+.rule-td { max-width:480px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+
+.linklike {
+  border:0;
+  background:transparent;
+  color:#7fb3ff;
+  cursor:pointer;
+}
+
+.linklike:hover { text-decoration:underline; }
+
+#ctx-menu {
+  position:fixed;
+  z-index:9999;
+  background:#111;
+  color:#eee;
+  border:1px solid #333;
+  border-radius:8px;
+  padding:6px;
+  min-width:180px;
+  box-shadow:0 8px 28px rgba(0,0,0,.25);
+}
+
+#ctx-menu[hidden] { display:none; }
+
+#ctx-menu .menu-item {
+  width:100%;
+  text-align:left;
+  border:0;
+  background:transparent;
+  color:#eee;
+  padding:8px 10px;
+  border-radius:6px;
+  cursor:pointer;
+  font-size:14px;
+}
+
+#ctx-menu .menu-item:hover { background:#1e1e1e; }
+
+#toast {
+  position:fixed;
+  bottom:20px;
+  right:20px;
+  z-index:9999;
+  background:#111;
+  color:#eee;
+  border:1px solid #333;
+  border-radius:10px;
+  padding:10px 14px;
+  font-size:14px;
+  box-shadow:0 8px 28px rgba(0,0,0,.25);
+}
+
+#toast[hidden] { display:none; }
+
+#scan-overlay {
+  position:fixed;
+  inset:0;
+  background:rgba(0,0,0,.5);
+  display:none;
+  place-items:center;
+  z-index:9998;
+}
+
+#scan-overlay .box {
+  background:#0f1220;
+  border:1px solid #223056;
+  padding:16px 18px;
+  border-radius:12px;
+  box-shadow:0 8px 40px rgba(0,0,0,.4);
+}
+
+#scan-overlay.htmx-request { display:grid !important; }
+.htmx-request #scan-results { opacity:.4; filter:grayscale(30%); }

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,64 +1,35 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>Pattern Finder — Archive</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <style>
-    :root { --card:#0e1116; --ink:#e8eefc; --muted:#99a3b3; }
-    html { font-size: clamp(16px, 1.2vw + 0.5rem, 22px); }
-    body { margin:0; background:#0b0e14; color:var(--ink); font-family: system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif; }
-    .wrap { max-width: 1400px; margin:0 auto; padding: clamp(16px, 2vw, 28px); }
-    .tabs { display:flex; gap:.75rem; flex-wrap:wrap; margin-bottom:1rem; }
-    .tab { text-decoration:none; color:var(--ink); padding:.6rem .9rem; border-radius:.8rem; background:#111726; border:1px solid #1a2337; }
-    .tab.active { background:linear-gradient(180deg,#16243b,#122033); border-color:#2a3a5d; box-shadow:0 6px 20px #000 inset,0 1px 0 #2a3a5d; }
-    .card { background: var(--card); border:1px solid #1a2337; border-radius:1rem; padding:1rem; box-shadow: 0 20px 60px rgba(0,0,0,.35); }
-    table { width:100%; border-collapse:collapse; }
-    th, td { padding:.75rem .8rem; border-bottom:1px solid #1a2337; vertical-align: top; }
-    th { text-align:left; color:#b9c7de; }
-    a.btn { text-decoration:none; color:var(--ink); background:#1a2337; padding:.35rem .6rem; border-radius:.6rem; border:1px solid #2a3a5d; font-size:.9rem; }
-  </style>
-</head>
-<body>
-  <div class="wrap">
-    <nav class="tabs">
-      <a class="tab" href="/scanner">Scanner</a>
-      <a class="tab" href="/favorites">Favorites</a>
-      <a class="tab active" href="/archive">Archive</a>
-      <a class="tab" href="/settings">Settings</a>
-    </nav>
-
-    <div class="card">
-      <h1 style="margin-top:0;">Archive</h1>
-      {% if runs and runs|length %}
-      <table>
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Started</th>
-            <th>Scan Type</th>
-            <th>Universe</th>
-            <th>Hits</th>
-            <th>Open</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for r in runs %}
-          <tr>
-            <td>{{ r["id"] }}</td>
-            <td>{{ r["started_at"] }}</td>
-            <td>{{ r["scan_type"] }}</td>
-            <td>{{ (r["universe"] or "").split(",") | length }}</td>
-            <td>{{ r["hit_count"] }}</td>
-            <td><a class="btn" href="/results/{{ r['id'] }}">View Results</a></td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-      {% else %}
-      <p>No archived runs yet.</p>
-      {% endif %}
-    </div>
+{% extends 'base.html' %}
+{% block title %}Pattern Finder — Archive{% endblock %}
+{% block content %}
+  <div class="card">
+    <h1 style="margin-top:0;">Archive</h1>
+    {% if runs and runs|length %}
+    <table class="table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Started</th>
+          <th>Scan Type</th>
+          <th>Universe</th>
+          <th>Hits</th>
+          <th>Open</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in runs %}
+        <tr>
+          <td>{{ r["id"] }}</td>
+          <td>{{ r["started_at"] }}</td>
+          <td>{{ r["scan_type"] }}</td>
+          <td>{{ (r["universe"] or "").split(",") | length }}</td>
+          <td>{{ r["hit_count"] }}</td>
+          <td><a class="btn" href="/results/{{ r['id'] }}">View Results</a></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <p>No archived runs yet.</p>
+    {% endif %}
   </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>{% block title %}Pattern Finder{% endblock %}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="{{ url_for('static', path='css/style.css') }}">
+  {% block head_extra %}{% endblock %}
+</head>
+<body>
+  <div class="wrap">
+    <nav class="tabs">
+      <a class="tab {% if active_tab=='scanner' %}active{% endif %}" href="/scanner">Scanner</a>
+      <a class="tab {% if active_tab=='favorites' %}active{% endif %}" href="/favorites">Favorites</a>
+      <a class="tab {% if active_tab=='archive' %}active{% endif %}" href="/archive">Archive</a>
+      <a class="tab {% if active_tab=='settings' %}active{% endif %}" href="/settings">Settings</a>
+    </nav>
+    {% block content %}{% endblock %}
+  </div>
+  {% block extra_body %}{% endblock %}
+  <div id="ctx-menu" hidden>
+    <button id="ctx-add-fav" class="menu-item">➕ Add to Favorites</button>
+  </div>
+  <div id="toast" hidden></div>
+</body>
+</html>

--- a/templates/favorites.html
+++ b/templates/favorites.html
@@ -1,74 +1,45 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>Pattern Finder — Favorites</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <style>
-    :root { --card:#0e1116; --ink:#e8eefc; --muted:#99a3b3; }
-    html { font-size: clamp(16px, 1.2vw + 0.5rem, 22px); }
-    body { margin:0; background:#0b0e14; color:var(--ink); font-family: system-ui, -apple-system, Segoe UI, Roboto, Inter, sans-serif; }
-    .wrap { max-width: 1400px; margin:0 auto; padding: clamp(16px, 2vw, 28px); }
-    .tabs { display:flex; gap:.75rem; flex-wrap:wrap; margin-bottom:1rem; }
-    .tab { text-decoration:none; color:var(--ink); padding:.6rem .9rem; border-radius:.8rem; background:#111726; border:1px solid #1a2337; }
-    .tab.active { background:linear-gradient(180deg,#16243b,#122033); border-color:#2a3a5d; box-shadow:0 6px 20px #000 inset, 0 1px 0 #2a3a5d; }
-    .card { background: var(--card); border:1px solid #1a2337; border-radius:1rem; padding:1rem; box-shadow: 0 20px 60px rgba(0,0,0,.35);}
-    table { width:100%; border-collapse: collapse; }
-    th, td { padding:.75rem .8rem; border-bottom:1px solid #1a2337; vertical-align: top; }
-    th { text-align:left; color:#b9c7de; }
-    code { color:#cfe1ff; }
-  </style>
-</head>
-<body>
-  <div class="wrap">
-    <nav class="tabs">
-      <a class="tab" href="/scanner">Scanner</a>
-      <a class="tab active" href="/favorites">Favorites</a>
-      <a class="tab" href="/archive">Archive</a>
-      <a class="tab" href="/settings">Settings</a>
-    </nav>
-
-    <div class="card">
-      <h1 style="margin-top:0;">Favorites</h1>
-      {% if favorites and favorites|length %}
-      <table>
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Ticker</th>
-            <th>Direction</th>
-            <th>Interval</th>
-            <th>ROI%</th>
-            <th>Hit%</th>
-            <th>DD%</th>
-            <th>Rule</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for f in favorites %}
-          <tr>
-            <td>{{ f["id"] }}</td>
-            <td><strong>{{ f["ticker"] }}</strong></td>
-            <td>{{ f["direction"] }}</td>
-            <td>{{ f["interval"] }}</td>
-            <td>{{ '{:.2f}'.format(f['avg_roi_pct']) if f['avg_roi_pct'] is not none else '' }}</td>
-            <td>{{ '{:.1f}'.format(f['hit_pct']) if f['hit_pct'] is not none else '' }}</td>
-            <td>{{ '{:.2f}'.format(f['avg_dd_pct']) if f['avg_dd_pct'] is not none else '' }}</td>
-            <td><code>{{ f["rule"] }}</code></td>
-            <td>
-              <form method="post" action="/favorites/delete/{{ f['id'] }}" style="margin:0;">
-                <button type="submit" style="background:none;border:none;color:var(--muted);cursor:pointer;">&#10005;</button>
-              </form>
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-      {% else %}
-      <p>No favorites yet. Right-click a row in Results to add one.</p>
-      {% endif %}
-    </div>
+{% extends 'base.html' %}
+{% block title %}Pattern Finder — Favorites{% endblock %}
+{% block content %}
+  <div class="card">
+    <h1 style="margin-top:0;">Favorites</h1>
+    {% if favorites and favorites|length %}
+    <table class="table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Ticker</th>
+          <th>Direction</th>
+          <th>Interval</th>
+          <th>ROI%</th>
+          <th>Hit%</th>
+          <th>DD%</th>
+          <th>Rule</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for f in favorites %}
+        <tr>
+          <td>{{ f["id"] }}</td>
+          <td><strong>{{ f["ticker"] }}</strong></td>
+          <td>{{ f["direction"] }}</td>
+          <td>{{ f["interval"] }}</td>
+          <td>{{ '{:.2f}'.format(f['avg_roi_pct']) if f['avg_roi_pct'] is not none else '' }}</td>
+          <td>{{ '{:.1f}'.format(f['hit_pct']) if f['hit_pct'] is not none else '' }}</td>
+          <td>{{ '{:.2f}'.format(f['avg_dd_pct']) if f['avg_dd_pct'] is not none else '' }}</td>
+          <td><code>{{ f["rule"] }}</code></td>
+          <td>
+            <form method="post" action="/favorites/delete/{{ f['id'] }}" style="margin:0;">
+              <button type="submit" style="background:none;border:none;color:var(--muted);cursor:pointer;">&#10005;</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <p>No favorites yet. Right-click a row in Results to add one.</p>
+    {% endif %}
   </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,213 +1,138 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>Pattern Finder — Scanner</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+{% extends 'base.html' %}
+{% block title %}Pattern Finder — Scanner{% endblock %}
+{% block head_extra %}
   <script src="https://unpkg.com/htmx.org@1.9.9/dist/htmx.min.js" defer></script>
   <script src="/static/js/scanner.js" defer></script>
-  <style>
-    :root { --card:#0e1116; --ink:#e8eefc; --muted:#99a3b3; --accent:#5ea0ff; --line:#1a2337; }
-    html { font-size: clamp(16px, 1.2vw + 0.5rem, 22px); }
-    body { margin:0; background:#0b0e14; color:var(--ink); font-family: system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif; }
-    .wrap { max-width: 1400px; margin: 0 auto; padding: clamp(16px, 2vw, 28px); }
-    .tabs { display:flex; gap:.75rem; flex-wrap:wrap; margin-bottom:1rem; }
-    .tab { text-decoration:none; color:var(--ink); padding:.6rem .9rem; border-radius:.8rem; background:#111726; border:1px solid var(--line); }
-    .tab.active { background:linear-gradient(180deg,#16243b,#122033); border-color:#2a3a5d; box-shadow:0 6px 20px #000 inset,0 1px 0 #2a3a5d; }
-    .card { background: var(--card); border:1px solid var(--line); border-radius: 1rem; padding:1rem; box-shadow: 0 20px 60px rgba(0,0,0,.35); }
-    .grid { display:grid; grid-template-columns: repeat(auto-fit,minmax(220px,1fr)); gap:1rem; }
-    label { display:block; color:var(--muted); margin-bottom:.35rem; }
-    input, select { width:100%; padding:.7rem .8rem; border-radius:.7rem; border:1px solid var(--line); background:#0c1220; color:var(--ink); font-size:1.1rem; }
-    .row { display:grid; grid-template-columns: repeat(auto-fit,minmax(220px,1fr)); gap:1rem; margin-top:.5rem; }
-    .actions { display:flex; gap:.7rem; flex-wrap:wrap; margin-top:1rem; align-items:center; }
-    button { cursor:pointer; background: var(--accent); border:none; color:#07101e; font-weight:700; padding:.8rem 1.1rem; border-radius:.8rem; }
-    .note { color: var(--muted); font-size:.95rem; }
-    .results-card { margin-top:1.2rem; border-radius:1rem; border:1px solid #223056; box-shadow: inset 0 0 0 1px #0b1020, 0 20px 60px rgba(0,0,0,.3); padding:1rem; }
-
-    /* Global ctx-menu + toast (live across swaps) */
-    #ctx-menu {
-      position: fixed; z-index: 9999; background: #111; color: #eee;
-      border: 1px solid #333; border-radius: 8px; padding: 6px; min-width: 200px;
-      box-shadow: 0 8px 28px rgba(0,0,0,.25);
-    }
-    #ctx-menu[hidden] { display:none; }
-    #ctx-menu .menu-item {
-      width: 100%; text-align: left; border: 0; background: transparent; color: #eee;
-      padding: 8px 10px; border-radius: 6px; cursor: pointer; font-size: 14px;
-    }
-    #ctx-menu .menu-item:hover { background: #1e1e1e; }
-    #toast {
-      position: fixed; bottom: 20px; right: 20px; z-index: 9999;
-      background: #111; color: #eee; border: 1px solid #333; border-radius: 10px;
-      padding: 10px 14px; font-size: 14px; box-shadow: 0 8px 28px rgba(0,0,0,.25);
-    }
-    #toast[hidden] { display:none; }
-
-    /* Spinner overlay */
-    #scan-overlay {
-      position: fixed; inset: 0; background: rgba(0,0,0,.5);
-      display: none; place-items: center; z-index: 9998;
-    }
-    #scan-overlay .box {
-      background: #0f1220; border:1px solid #223056; padding:16px 18px; border-radius:12px;
-      box-shadow: 0 8px 40px rgba(0,0,0,.4);
-    }
-  
-  /* Show spinner overlay while HTMX request is active */
-  #scan-overlay.htmx-request { display:grid !important; }
-  /* optional: dim the results area while loading */
-  .htmx-request #scan-results { opacity:.4; filter:grayscale(30%); }
-
-</style>
-</head>
-<body>
-  <div class="wrap">
-    <nav class="tabs">
-      <a class="tab active" href="/scanner">Scanner</a>
-      <a class="tab" href="/favorites">Favorites</a>
-      <a class="tab" href="/archive">Archive</a>
-      <a class="tab" href="/settings">Settings</a>
-    </nav>
-
-    <div class="card">
-      <h1 style="margin:0 0 1rem 0">Scanner</h1>
-
-      <!-- Form -->
-      <form id="scan-form" action="/scanner/run" method="post"
-            hx-post="/scanner/run" hx-target="#scan-results" hx-indicator="#scan-overlay">
-        <div class="row">
-          <div>
-            <label>Scan Type</label>
-            <select name="scan_type" required>
-              <option value="scan150">Top 150</option>
-              <option value="sp100">S&amp;P 100</option>
-              <option value="single">Single Ticker</option>
+{% endblock %}
+{% block content %}
+  <div class="card">
+    <h1 style="margin:0 0 1rem 0">Scanner</h1>
+    <form id="scan-form" action="/scanner/run" method="post"
+          hx-post="/scanner/run" hx-target="#scan-results" hx-indicator="#scan-overlay">
+      <div class="row">
+        <div>
+          <label>Scan Type</label>
+          <select name="scan_type" required>
+            <option value="scan150">Top 150</option>
+            <option value="sp100">S&amp;P 100</option>
+            <option value="single">Single Ticker</option>
+          </select>
+        </div>
+        <div>
+          <label>Ticker (for Single)</label>
+          <input name="ticker" placeholder="AAPL" />
+        </div>
+        <div>
+          <label>Interval</label>
+          <select name="interval">
+            <option>15m</option><option>5m</option><option>30m</option><option>1h</option>
+          </select>
+        </div>
+        <div>
+          <label>Direction</label>
+          <select name="direction">
+            <option>BOTH</option><option>UP</option><option>DOWN</option>
+          </select>
+        </div>
+        <div>
+          <label>Target %</label>
+          <input name="target_pct" type="number" step="0.01" value="1.0" />
+        </div>
+        <div>
+          <label>Stop %</label>
+          <input name="stop_pct" type="number" step="0.01" value="0.5" />
+        </div>
+        <div>
+          <label>Within</label>
+          <div style="display:flex; gap:.5rem;">
+            <input name="window_value" type="number" step="0.5" value="4.0" style="flex:1;" />
+            <select name="window_unit" style="flex:1;">
+              <option>Hours</option><option>Days</option>
             </select>
           </div>
-          <div>
-            <label>Ticker (for Single)</label>
-            <input name="ticker" placeholder="AAPL" />
-          </div>
-          <div>
-            <label>Interval</label>
-            <select name="interval">
-              <option>15m</option><option>5m</option><option>30m</option><option>1h</option>
-            </select>
-          </div>
-          <div>
-            <label>Direction</label>
-            <select name="direction">
-              <option>BOTH</option><option>UP</option><option>DOWN</option>
-            </select>
-          </div>
-          <div>
-            <label>Target %</label>
-            <input name="target_pct" type="number" step="0.01" value="1.0" />
-          </div>
-          <div>
-            <label>Stop %</label>
-            <input name="stop_pct" type="number" step="0.01" value="0.5" />
-          </div>
-          <div>
-            <label>Within</label>
-            <div style="display:flex; gap:.5rem;">
-              <input name="window_value" type="number" step="0.5" value="4.0" style="flex:1;" />
-              <select name="window_unit" style="flex:1;">
-                <option>Hours</option><option>Days</option>
-              </select>
-            </div>
-          </div>
-          <div>
-            <label>Lookback (years)</label>
-            <input name="lookback_years" type="number" step="0.1" value="2.0" />
-          </div>
-          <div>
-            <label>Max TT Bars</label>
-            <input name="max_tt_bars" type="number" step="1" value="12" />
-          </div>
-          <div>
-            <label>Min Support</label>
-            <input name="min_support" type="number" step="1" value="20" />
-          </div>
-          <div>
-            <label>Delta (assumed)</label>
-            <input name="delta_assumed" type="number" step="0.01" value="0.40" />
-          </div>
-          <div>
-            <label>Theta per day %</label>
-            <input name="theta_per_day_pct" type="number" step="0.01" value="0.20" />
-          </div>
-          <div>
-            <label>ATRz gate</label>
-            <input name="atrz_gate" type="number" step="0.01" value="0.10" />
-          </div>
-          <div>
-            <label>Slope gate %</label>
-            <input name="slope_gate_pct" type="number" step="0.01" value="0.02" />
-          </div>
-          <div>
-            <label>Use Regime</label>
-            <select name="use_regime"><option value="0">No</option><option value="1">Yes</option></select>
-          </div>
-          <div>
-            <label>Regime Trend Only</label>
-            <select name="regime_trend_only"><option value="0">No</option><option value="1">Yes</option></select>
-          </div>
-          <div>
-            <label>VIX z max</label>
-            <input name="vix_z_max" type="number" step="0.1" value="3.0" />
-          </div>
-          <div>
-            <label>Slippage (bps)</label>
-            <input name="slippage_bps" type="number" step="1" value="7" />
-          </div>
-          <div>
-            <label>Vega scale</label>
-            <input name="vega_scale" type="number" step="0.01" value="0.03" />
-          </div>
-          <div>
-            <label>Scan min Hit %</label>
-            <input name="scan_min_hit" type="number" step="1" value="50" />
-          </div>
-          <div>
-            <label>Scan max DD %</label>
-            <input name="scan_max_dd" type="number" step="1" value="50" />
-          </div>
-          <div>
-            <label>Email results</label>
-            <select name="email_checkbox"><option value="">No</option><option value="on">Yes</option></select>
-          </div>
         </div>
+        <div>
+          <label>Lookback (years)</label>
+          <input name="lookback_years" type="number" step="0.1" value="2.0" />
+        </div>
+        <div>
+          <label>Max TT Bars</label>
+          <input name="max_tt_bars" type="number" step="1" value="12" />
+        </div>
+        <div>
+          <label>Min Support</label>
+          <input name="min_support" type="number" step="1" value="20" />
+        </div>
+        <div>
+          <label>Delta (assumed)</label>
+          <input name="delta_assumed" type="number" step="0.01" value="0.40" />
+        </div>
+        <div>
+          <label>Theta per day %</label>
+          <input name="theta_per_day_pct" type="number" step="0.01" value="0.20" />
+        </div>
+        <div>
+          <label>ATRz gate</label>
+          <input name="atrz_gate" type="number" step="0.01" value="0.10" />
+        </div>
+        <div>
+          <label>Slope gate %</label>
+          <input name="slope_gate_pct" type="number" step="0.01" value="0.02" />
+        </div>
+        <div>
+          <label>Use Regime</label>
+          <select name="use_regime"><option value="0">No</option><option value="1">Yes</option></select>
+        </div>
+        <div>
+          <label>Regime Trend Only</label>
+          <select name="regime_trend_only"><option value="0">No</option><option value="1">Yes</option></select>
+        </div>
+        <div>
+          <label>VIX z max</label>
+          <input name="vix_z_max" type="number" step="0.1" value="3.0" />
+        </div>
+        <div>
+          <label>Slippage (bps)</label>
+          <input name="slippage_bps" type="number" step="1" value="7" />
+        </div>
+        <div>
+          <label>Vega scale</label>
+          <input name="vega_scale" type="number" step="0.01" value="0.03" />
+        </div>
+        <div>
+          <label>Scan min Hit %</label>
+          <input name="scan_min_hit" type="number" step="1" value="50" />
+        </div>
+        <div>
+          <label>Scan max DD %</label>
+          <input name="scan_max_dd" type="number" step="1" value="50" />
+        </div>
+        <div>
+          <label>Email results</label>
+          <select name="email_checkbox"><option value="">No</option><option value="on">Yes</option></select>
+        </div>
+      </div>
 
-        <div class="actions">
-          <button type="submit">Run Scan</button>
-          <span class="note">Results appear below with sortable buttons.</span>
-        </div>
+      <div class="actions">
+        <button type="submit">Run Scan</button>
+        <span class="note">Results appear below with sortable buttons.</span>
+      </div>
 
-        <div class="actions" style="margin-top:1rem;">
-          <button type="submit" name="sort" value="ticker">Sort: Ticker</button>
-          <button type="submit" name="sort" value="roi">Sort: ROI</button>
-          <button type="submit" name="sort" value="hit">Sort: Hit%</button>
-        </div>
-      </form>
+      <div class="actions" style="margin-top:1rem;">
+        <button type="submit" name="sort" value="ticker">Sort: Ticker</button>
+        <button type="submit" name="sort" value="roi">Sort: ROI</button>
+        <button type="submit" name="sort" value="hit">Sort: Hit%</button>
+      </div>
+    </form>
 
-      <div class="results-card">
-        <h2 style="margin:0 0 .5rem 0">Results</h2>
-        <div id="scan-results">
-          <p>No results.</p>
-        </div>
+    <div class="results-card">
+      <h2 style="margin:0 0 .5rem 0">Results</h2>
+      <div id="scan-results">
+        <p>No results.</p>
       </div>
     </div>
   </div>
-
-  <!-- Global context menu + toast lives outside swapped area -->
-  <div id="ctx-menu" hidden>
-    <button id="ctx-add-fav" class="menu-item">➕ Add to Favorites</button>
-  </div>
-  <div id="toast" hidden></div>
-
-  <!-- Spinner overlay -->
+{% endblock %}
+{% block extra_body %}
   <div id="scan-overlay"><div class="box">⏳ Running scan…</div></div>
-
-</body>
-</html>
+{% endblock %}

--- a/templates/results.html
+++ b/templates/results.html
@@ -52,50 +52,6 @@
   {% endif %}
 </div>
 
-<!-- Context menu -->
-<div id="ctx-menu" hidden>
-  <button id="ctx-add-fav" class="menu-item">➕ Add to Favorites</button>
-</div>
-
-<!-- Toast -->
-<div id="toast" hidden></div>
-
-<style>
-  #ctx-menu {
-    position: fixed; z-index: 9999;
-    background: #111; color: #eee;
-    border: 1px solid #333; border-radius: 8px;
-    padding: 6px; min-width: 180px;
-    box-shadow: 0 8px 28px rgba(0,0,0,.25);
-  }
-  #ctx-menu .menu-item {
-    width: 100%; text-align: left; border: 0; background: transparent; color: #eee;
-    padding: 8px 10px; border-radius: 6px; cursor: pointer; font-size: 14px;
-  }
-  #ctx-menu .menu-item:hover { background: #1e1e1e; }
-  #toast {
-    position: fixed; bottom: 20px; right: 20px; z-index: 9999;
-    background: #111; color: #eee; border: 1px solid #333; border-radius: 10px;
-    padding: 10px 14px; font-size: 14px; box-shadow: 0 8px 28px rgba(0,0,0,.25);
-  }
-  .table { width:100%; border-collapse:collapse; }
-  .table th, .table td {
-    padding:.6rem .8rem;
-    border-bottom:1px solid var(--line, #1a2337);
-    vertical-align:top;
-  }
-  .table th { text-align:left; color:#b9c7de; }
-  .table tbody tr:hover { background:#111726; }
-  .row-hover { cursor: pointer; }
-  .rule-td { max-width: 480px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .linklike { border: 0; background: transparent; color: #7fb3ff; cursor: pointer; }
-  .linklike:hover { text-decoration: underline; }
-  .btn {
-    border: 1px solid #2b2b2b; background:#161616; color:#eee; 
-    border-radius: 10px; padding: 6px 10px; cursor: pointer;
-  }
-  .btn:hover { background:#1e1e1e; }
-</style>
 
 <script>
 (function attachResultsBehaviors(){

--- a/templates/results_page.html
+++ b/templates/results_page.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block title %}Pattern Finder — Results{% endblock %}
+{% block content %}
+  {% include 'results.html' %}
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,73 +1,42 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>Pattern Finder — Settings</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <style>
-    :root { --card:#0e1116; --ink:#e8eefc; --muted:#99a3b3; --accent:#5ea0ff; }
-    html { font-size: clamp(16px, 1.2vw + 0.5rem, 22px); }
-    body { margin:0; background:#0b0e14; color:var(--ink); font-family: system-ui, -apple-system, Segoe UI, Roboto, Inter, sans-serif; }
-    .wrap { max-width: 1000px; margin:0 auto; padding: clamp(16px, 2vw, 28px); }
-    .tabs { display:flex; gap:.75rem; flex-wrap:wrap; margin-bottom:1rem; }
-    .tab { text-decoration:none; color:var(--ink); padding:.6rem .9rem; border-radius:.8rem; background:#111726; border:1px solid #1a2337; }
-    .tab.active { background:linear-gradient(180deg,#16243b,#122033); border-color:#2a3a5d; box-shadow:0 6px 20px #000 inset, 0 1px 0 #2a3a5d; }
-    .card { background: var(--card); border:1px solid #1a2337; border-radius:1rem; padding:1rem; box-shadow: 0 20px 60px rgba(0,0,0,.35);}
-    .grid { display:grid; grid-template-columns: repeat(auto-fit,minmax(260px,1fr)); gap:1rem; }
-    label { display:block; color:var(--muted); margin-bottom:.35rem; }
-    input, select { width:100%; padding:.7rem .8rem; border-radius:.7rem; border:1px solid #1a2337; background:#0c1220; color:var(--ink); font-size:1.1rem; }
-    .actions { margin-top:1rem; }
-    button { cursor:pointer; background: var(--accent); border:none; color:#07101e; font-weight:700; padding:.8rem 1.1rem; border-radius:.8rem; }
-    .note { color: var(--muted); font-size:.95rem; }
-  </style>
-</head>
-<body>
-  <div class="wrap">
-    <nav class="tabs">
-      <a class="tab" href="/scanner">Scanner</a>
-      <a class="tab" href="/favorites">Favorites</a>
-      <a class="tab" href="/archive">Archive</a>
-      <a class="tab active" href="/settings">Settings</a>
-    </nav>
-
-    <div class="card">
-      <h1 style="margin-top:0;">Settings</h1>
-      <form action="/settings/save" method="post">
-        <div class="grid">
-          <div>
-            <label>SMTP User</label>
-            <input name="smtp_user" value="{{ st['smtp_user'] or '' }}" />
-          </div>
-          <div>
-            <label>SMTP Pass</label>
-            <input name="smtp_pass" type="password" value="{{ st['smtp_pass'] or '' }}" />
-          </div>
-          <div>
-            <label>Recipients (comma-separated)</label>
-            <input name="recipients" value="{{ st['recipients'] or '' }}" />
-          </div>
-          <div>
-            <label>Enable Favorites Scheduler</label>
-            <select name="scheduler_enabled">
-              <option value="1" {% if st['scheduler_enabled']==1 %}selected{% endif %}>Yes</option>
-              <option value="0" {% if st['scheduler_enabled']==0 %}selected{% endif %}>No</option>
-            </select>
-          </div>
-          <div>
-            <label>Throttle Window (minutes)</label>
-            <input name="throttle_minutes" type="number" step="1" value="{{ st['throttle_minutes'] or 60 }}" />
-          </div>
+{% extends 'base.html' %}
+{% block title %}Pattern Finder — Settings{% endblock %}
+{% block content %}
+  <div class="card">
+    <h1 style="margin-top:0;">Settings</h1>
+    <form action="/settings/save" method="post">
+      <div class="grid">
+        <div>
+          <label>SMTP User</label>
+          <input name="smtp_user" value="{{ st['smtp_user'] or '' }}" />
         </div>
-
-        <div class="actions">
-          <button type="submit">Save</button>
-          <p class="note">
-            Current boundary: <strong>{{ st['last_boundary'] or '—' }}</strong> &nbsp;•&nbsp;
-            Last run at: <strong>{{ st['last_run_at'] or '—' }}</strong>
-          </p>
+        <div>
+          <label>SMTP Pass</label>
+          <input name="smtp_pass" type="password" value="{{ st['smtp_pass'] or '' }}" />
         </div>
-      </form>
-    </div>
+        <div>
+          <label>Recipients (comma-separated)</label>
+          <input name="recipients" value="{{ st['recipients'] or '' }}" />
+        </div>
+        <div>
+          <label>Enable Favorites Scheduler</label>
+          <select name="scheduler_enabled">
+            <option value="1" {% if st['scheduler_enabled']==1 %}selected{% endif %}>Yes</option>
+            <option value="0" {% if st['scheduler_enabled']==0 %}selected{% endif %}>No</option>
+          </select>
+        </div>
+        <div>
+          <label>Throttle Window (minutes)</label>
+          <input name="throttle_minutes" type="number" step="1" value="{{ st['throttle_minutes'] or 60 }}" />
+        </div>
+      </div>
+
+      <div class="actions">
+        <button type="submit">Save</button>
+        <p class="note">
+          Current boundary: <strong>{{ st['last_boundary'] or '—' }}</strong> &nbsp;•&nbsp;
+          Last run at: <strong>{{ st['last_run_at'] or '—' }}</strong>
+        </p>
+      </div>
+    </form>
   </div>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Centralize shared layout and navigation in new `base.html`
- Move styling into new global stylesheet and remove inline CSS
- Update routes and templates to use unified design and active tab highlighting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be53d3b46883299c8f67e031c59d40