### PR TITLE
Add Top250 options ticker universe

### DIFF
--- a/indices.py
+++ b/indices.py
@@ -19,3 +19,24 @@ TOP150 = [
     "DOW","CF","MOS","FSLR","ENPH","SEDG","BLK","SCHW","MSCI","SPGI","ICE","CME","COIN","SOFI","IYR","O",
     "AMT","PLD","EQIX","BABA","JD","PDD","NIO","XPEV","LI","ROKU","RBLX","RIVN","LCID"
 ]
+
+TOP250 = [
+    "SPY","QQQ","AAPL","MSFT","NVDA","AMZN","TSLA","META","GOOGL","AMD","NFLX","AVGO","CRM","ADBE",
+    "PYPL","INTC","ORCL","CSCO","QCOM","TXN","MU","SMCI","PLTR","SNOW","NOW","TEAM","JPM","BAC",
+    "GS","MS","WFC","C","V","MA","AXP","KO","PEP","PG","PM","T","VZ","HD",
+    "LOW","COST","WMT","DIS","CMCSA","TGT","MCD","SBUX","ABNB","UBER","NKE","DE","CAT","BA",
+    "GE","GM","F","XOM","CVX","SLB","COP","OXY","PFE","MRK","LLY","ABBV","BMY","UNH",
+    "TMO","ISRG","MDT","CVS","CI","HUM","VRTX","REGN","PANW","FTNT","CRWD","ZS","OKTA","DDOG",
+    "NET","CHTR","TMUS","NOC","LMT","RTX","HON","MMM","DELL","HPQ","IBM","INTU","ADP","WDAY",
+    "ORLY","AZO","DAL","UAL","LUV","CCL","RCL","CMG","DPZ","YUM","FCX","NUE","APD","LIN",
+    "DOW","CF","MOS","FSLR","ENPH","SEDG","BLK","SCHW","MSCI","SPGI","ICE","CME","COIN","SOFI",
+    "IYR","O","AMT","PLD","EQIX","BABA","JD","PDD","NIO","XPEV","LI","ROKU","RBLX","RIVN",
+    "LCID","ABT","ACN","AMGN","BK","BRK-B","CL","COF","DHR","DUK","EMR","EXC","FDX","GILD",
+    "JNJ","KHC","MDLZ","MET","MO","NEE","SO","UNP","UPS","USB","WBA","WELL","AAL","AAP",
+    "A","AEP","AES","AFL","AIG","AIZ","AKAM","ALB","ALGN","ALK","ALL","ALLE","AMAT","AON",
+    "AOS","APTV","ARE","ATO","ATVI","AWK","BALL","BDX","BEN","BIIB","BIO","BKR","BLL","BXP",
+    "CAG","CAH","CARR","CDNS","CDW","CE","CHD","CINF","CLX","CMA","CMS","CNC","CNP","CPRT",
+    "CTAS","CTLT","CTSH","D","DD","DHI","DLR","DOV","DTE","DXCM","EA","EBAY","ECL","ED",
+    "EFX","EIX","EL","EQR","ETR","ETSY","FAST","FDS","FE","FLT","FMC","FRT","GEHC","GLW",
+    "GPC","GPN","GRMN","HAL","HAS","HBAN","HCA","HES","HIG","HLT","HOLX","HRL"
+]

--- a/pattern_finder_app.py
+++ b/pattern_finder_app.py
@@ -32,7 +32,7 @@ from sklearn.tree import DecisionTreeRegressor
 from sklearn.model_selection import TimeSeriesSplit
 
 from multiprocessing import Pool, cpu_count
-from indices import SP100, TOP150  # Index lists
+from indices import SP100, TOP150, TOP250  # Index lists
 
 # Trust store for TLS (fixes CERTIFICATE_VERIFY_FAILED on macOS)
 os.environ.setdefault("SSL_CERT_FILE", certifi.where())
@@ -1131,8 +1131,11 @@ class App:
     # ---------- Scanner ----------
     def on_scan(self, which="sp"):
         try:
-            p=self._params(); self.status.set(f"Scanning {'S&P100' if which=='sp' else 'Top150'}…"); self.root.update_idletasks()
-            tickers=SP100 if which=="sp" else TOP150
+            p=self._params(); label = 'S&P100' if which=='sp' else 'Top250' if which=='top250' else 'Top150'
+            self.status.set(f"Scanning {label}…"); self.root.update_idletasks()
+            if which=="sp": tickers=SP100
+            elif which=="top250": tickers=TOP250
+            else: tickers=TOP150
             ev_dates=load_event_dates_from_csv(self.events.get())
             ev_masks={}
             for t in tickers:

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Request, Form, Depends
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 
-from indices import SP100, TOP150
+from indices import SP100, TOP150, TOP250
 from db import DB_PATH, get_db, get_settings
 from scanner import compute_scan_for_ticker
 from utils import now_et
@@ -298,6 +298,8 @@ async def scanner_run(request: Request):
         tickers = [single_ticker]
     elif scan_type.lower() in ("sp100", "sp_100", "sp100_scan"):
         tickers = SP100
+    elif scan_type.lower() in ("top250", "scan250", "options250"):
+        tickers = TOP250
     else:
         # default Top 150
         tickers = TOP150

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,7 @@
           <label>Scan Type</label>
           <select name="scan_type" required>
             <option value="scan150">Top 150</option>
+            <option value="scan250">Top 250</option>
             <option value="sp100">S&amp;P 100</option>
             <option value="single">Single Ticker</option>
           </select>


### PR DESCRIPTION
## Summary
- include `TOP250` list of optionable tickers
- allow scanner and desktop app to run against Top 250 universe
- expose Top 250 option in web UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be59fac4fc8329b68fa3eb38e18193