### PR TITLE
Add duplicate removal for favorites and enlarge delete button

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -179,6 +179,20 @@ def favorites_delete(fav_id: int, db=Depends(get_db)):
     return RedirectResponse(url="/favorites", status_code=302)
 
 
+@router.post("/favorites/delete-duplicates")
+def favorites_delete_duplicates(db=Depends(get_db)):
+    db.execute(
+        """
+        DELETE FROM favorites
+        WHERE id NOT IN (
+            SELECT MIN(id) FROM favorites GROUP BY ticker, direction, interval, rule
+        )
+        """
+    )
+    db.connection.commit()
+    return RedirectResponse(url="/favorites", status_code=302)
+
+
 @router.post("/favorites/add")
 async def favorites_add(request: Request, db=Depends(get_db)):
     payload = await request.json()

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -119,6 +119,15 @@ button, .btn {
 
 .rule-td { max-width:480px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 
+.del-btn {
+  background:none;
+  border:none;
+  color:var(--muted);
+  cursor:pointer;
+  font-size:1.2rem;
+  line-height:1;
+}
+
 .linklike {
   border:0;
   background:transparent;

--- a/templates/favorites.html
+++ b/templates/favorites.html
@@ -4,6 +4,11 @@
   <div class="card">
     <h1 style="margin-top:0;">Favorites</h1>
     {% if favorites and favorites|length %}
+    <div class="actions">
+      <form method="post" action="/favorites/delete-duplicates" style="margin:0;">
+        <button type="submit">Remove Duplicates</button>
+      </form>
+    </div>
     <table class="table">
       <thead>
         <tr>
@@ -31,7 +36,7 @@
           <td><code>{{ f["rule"] }}</code></td>
           <td>
             <form method="post" action="/favorites/delete/{{ f['id'] }}" style="margin:0;">
-              <button type="submit" style="background:none;border:none;color:var(--muted);cursor:pointer;">&#10005;</button>
+              <button type="submit" class="del-btn">&#10005;</button>
             </form>
           </td>
         </tr>

--- a/tests/test_favorites.py
+++ b/tests/test_favorites.py
@@ -1,0 +1,34 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import db
+from routes import favorites_delete_duplicates
+
+
+def test_delete_duplicates(tmp_path):
+    db.DB_PATH = str(tmp_path / "test.db")
+    db.init_db()
+
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO favorites(ticker, direction, interval, rule) VALUES ('AAA','UP','15m','r1')"
+    )
+    cur.execute(
+        "INSERT INTO favorites(ticker, direction, interval, rule) VALUES ('AAA','UP','15m','r1')"
+    )
+    cur.execute(
+        "INSERT INTO favorites(ticker, direction, interval, rule) VALUES ('BBB','DOWN','15m','r2')"
+    )
+    conn.commit()
+
+    favorites_delete_duplicates(db=cur)
+
+    cur.execute("SELECT COUNT(*) FROM favorites")
+    count = cur.fetchone()[0]
+    assert count == 2
+    conn.close()
+


### PR DESCRIPTION
## Summary
- add "Remove Duplicates" button on Favorites page
- enlarge the per-row delete "x" button
- provide backend route and test for deduplicating favorites

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be603ed5a4832987648b6373f38a8a