### PR TITLE
Display rules for archived runs and format archive names

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -19,7 +19,7 @@
         {% for r in runs %}
         <tr>
           <td>{{ r["id"] }}</td>
-          <td>{{ r["started_at"] }}</td>
+          <td>{{ r["started_display"] }}</td>
           <td>{{ r["scan_type"] }}</td>
           <td>{{ (r["universe"] or "").split(",") | length }}</td>
           <td>{{ r["hit_count"] }}</td>

--- a/templates/results_page.html
+++ b/templates/results_page.html
@@ -1,5 +1,10 @@
 {% extends 'base.html' %}
 {% block title %}Pattern Finder — Results{% endblock %}
 {% block content %}
+  {% if rule_summary %}
+  <div class="card" style="margin-bottom:1rem;">
+    <div class="card-body"><strong>Rules:</strong> {{ rule_summary }}</div>
+  </div>
+  {% endif %}
   {% include 'results.html' %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- show archived scan parameters above result tables
- format archive entries with Eastern time and target/stop values
- save archive runs with Eastern time stamps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be624a064883299cdf14244675355d