### PR TITLE
Add forward test tab to monitor favorites

### DIFF
--- a/db.py
+++ b/db.py
@@ -55,6 +55,19 @@ SCHEMA = [
         ref_avg_dd REAL
     );
     """,
+    # Forward test results
+    """
+    CREATE TABLE IF NOT EXISTS forward_tests (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        fav_id INTEGER NOT NULL,
+        ran_at TEXT,
+        avg_roi_pct REAL,
+        hit_pct REAL,
+        avg_dd_pct REAL,
+        FOREIGN KEY(fav_id) REFERENCES favorites(id)
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_forward_tests_fav ON forward_tests(fav_id);",
     # Runs (archive)
     """
     CREATE TABLE IF NOT EXISTS runs (

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
     <nav class="tabs">
       <a class="tab {% if active_tab=='scanner' %}active{% endif %}" href="/scanner">Scanner</a>
       <a class="tab {% if active_tab=='favorites' %}active{% endif %}" href="/favorites">Favorites</a>
+      <a class="tab {% if active_tab=='forward' %}active{% endif %}" href="/forward">Forward Test</a>
       <a class="tab {% if active_tab=='archive' %}active{% endif %}" href="/archive">Archive</a>
       <a class="tab {% if active_tab=='settings' %}active{% endif %}" href="/settings">Settings</a>
     </nav>

--- a/templates/forward.html
+++ b/templates/forward.html
@@ -1,0 +1,47 @@
+{% extends 'base.html' %}
+{% block title %}Pattern Finder — Forward Test{% endblock %}
+{% block content %}
+  <div class="card">
+    <h1 style="margin-top:0;">Forward Test</h1>
+    {% if tests and tests|length %}
+    <table class="table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Ticker</th>
+          <th>Direction</th>
+          <th>Interval</th>
+          <th>ROI%</th>
+          <th>Hit%</th>
+          <th>DD%</th>
+          <th>Last Run</th>
+          <th>Rule</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for f in tests %}
+        <tr>
+          <td>{{ f["id"] }}</td>
+          <td><strong>{{ f["ticker"] }}</strong></td>
+          <td>{{ f["direction"] }}</td>
+          <td>{{ f["interval"] }}</td>
+          <td>{{ '{:.0f}'.format(f['avg_roi_pct']*100 if f['avg_roi_pct'] is not none and f['avg_roi_pct'] <= 1 else f['avg_roi_pct']) if f['avg_roi_pct'] is not none else '' }}</td>
+          <td>{{ '{:.1f}'.format(f['hit_pct']) if f['hit_pct'] is not none else '' }}</td>
+          <td>{{ '{:.0f}'.format(f['avg_dd_pct']*100 if f['avg_dd_pct'] is not none and f['avg_dd_pct'] <= 1 else f['avg_dd_pct']) if f['avg_dd_pct'] is not none else '' }}</td>
+          <td>{{ f["ran_at"][:16] if f["ran_at"] else '' }}</td>
+          <td><code>{{ f["rule"] }}</code></td>
+          <td>
+            <form method="post" action="/favorites/delete/{{ f['id'] }}" style="margin:0;">
+              <button type="submit" class="del-btn">&#10005;</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <p>No favorites to test.</p>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -15,3 +15,14 @@ def test_init_db_creates_settings(tmp_path):
     settings = db.get_settings(cur)
     assert settings["id"] == 1
     gen.close()
+
+
+def test_forward_tests_table_exists(tmp_path):
+    db.DB_PATH = str(tmp_path / "test.db")
+    db.init_db()
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='forward_tests'")
+    row = cur.fetchone()
+    conn.close()
+    assert row is not None

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1,0 +1,45 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+from starlette.requests import Request
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import db
+from routes import forward_page
+import routes
+
+
+def test_forward_page_runs_scan_and_records(tmp_path, monkeypatch):
+    db.DB_PATH = str(tmp_path / "test.db")
+    db.init_db()
+    conn = sqlite3.connect(db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO favorites(ticker, direction, interval, rule) VALUES ('AAA','UP','15m','r1')"
+    )
+    conn.commit()
+
+    def fake_scan(ticker, params):
+        return {"avg_roi_pct": 0.5, "hit_pct": 60.0, "avg_dd_pct": 0.1}
+
+    monkeypatch.setattr(routes, "compute_scan_for_ticker", fake_scan)
+
+    class DummyResponse:
+        def __init__(self, name, context):
+            self.template = type("T", (), {"name": name})
+            self.context = context
+
+    def dummy_template_response(name, context):
+        return DummyResponse(name, context)
+
+    monkeypatch.setattr(routes.templates, "TemplateResponse", dummy_template_response)
+
+    request = Request({"type": "http"})
+    resp = forward_page(request, db=cur)
+    assert resp.template.name == "forward.html"
+    cur.execute("SELECT COUNT(*) FROM forward_tests")
+    assert cur.fetchone()[0] == 1
+    conn.close()


### PR DESCRIPTION
## Summary
- add database table to store forward test results
- add Forward Test tab and route for re-evaluating favorites
- include tests for new database table and route

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be66e8bef48329bc2e1180186fb8b0