### PR TITLE
Handle string percent values in archive

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -108,9 +108,15 @@ def results_from_archive(request: Request, run_id: int, db=Depends(get_db)):
         stp = params.get("stop_pct")
         parts = []
         if tgt is not None:
-            parts.append(f"Target,{tgt:g}%")
+            try:
+                parts.append(f"Target,{float(tgt):g}%")
+            except (ValueError, TypeError):
+                parts.append(f"Target,{tgt}%")
         if stp is not None:
-            parts.append(f"Stop,{stp:g}%")
+            try:
+                parts.append(f"Stop,{float(stp):g}%")
+            except (ValueError, TypeError):
+                parts.append(f"Stop,{stp}%")
         rule_summary = "-".join(parts)
 
         dt = datetime.fromisoformat(run["started_at"])
@@ -251,9 +257,15 @@ def archive_page(request: Request, db=Depends(get_db)):
         stp = params.get("stop_pct")
         parts = []
         if tgt is not None:
-            parts.append(f"Target,{tgt:g}%")
+            try:
+                parts.append(f"Target,{float(tgt):g}%")
+            except (ValueError, TypeError):
+                parts.append(f"Target,{tgt}%")
         if stp is not None:
-            parts.append(f"Stop,{stp:g}%")
+            try:
+                parts.append(f"Stop,{float(stp):g}%")
+            except (ValueError, TypeError):
+                parts.append(f"Stop,{stp}%")
         rule_summary = "-".join(parts)
         try:
             dt = datetime.fromisoformat(r["started_at"])


### PR DESCRIPTION
## Summary
- Fix archive page crash by safely formatting target/stop percentages when stored as strings
- Apply same robust formatting to run detail view

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be6874f57083299a2369b446ab70ba