### PR TITLE
Add scanning progress bar overlay

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -198,5 +198,25 @@ button, .btn {
   box-shadow:0 8px 40px rgba(0,0,0,.4);
 }
 
+#progress-bar {
+  width:200px;
+  height:16px;
+  background:#1a2337;
+  border-radius:8px;
+  overflow:hidden;
+}
+
+#progress-fill {
+  height:100%;
+  width:0%;
+  background:var(--accent);
+  transition:width .1s linear;
+}
+
+#progress-text {
+  margin-top:.5rem;
+  text-align:center;
+}
+
 #scan-overlay.htmx-request { display:grid !important; }
 .htmx-request #scan-results { opacity:.4; filter:grayscale(30%); }

--- a/static/js/scanner.js
+++ b/static/js/scanner.js
@@ -2,10 +2,38 @@
   const overlay = document.getElementById('scan-overlay');
   const menu = document.getElementById('ctx-menu');
   const toast = document.getElementById('toast');
+  const progressFill = document.getElementById('progress-fill');
+  const progressText = document.getElementById('progress-text');
   let ctxRow = null; // current row element
+  let progressTimer = null;
 
-  function showOverlay(){ overlay.style.display = 'grid'; }
-  function hideOverlay(){ overlay.style.display = 'none'; }
+  function startProgress(){
+    let pct = 0;
+    progressFill.style.width = '0%';
+    progressText.textContent = '0%';
+    clearInterval(progressTimer);
+    progressTimer = setInterval(()=>{
+      pct = Math.min(pct + 1, 100);
+      progressFill.style.width = pct + '%';
+      progressText.textContent = pct + '%';
+      if (pct >= 100) clearInterval(progressTimer);
+    },50);
+  }
+
+  function stopProgress(){
+    clearInterval(progressTimer);
+    progressFill.style.width = '100%';
+    progressText.textContent = '100%';
+  }
+
+  function showOverlay(){
+    overlay.style.display = 'grid';
+    startProgress();
+  }
+  function hideOverlay(){
+    overlay.style.display = 'none';
+    stopProgress();
+  }
 
   function showMenu(x,y, tr){
     ctxRow = tr;

--- a/templates/index.html
+++ b/templates/index.html
@@ -135,5 +135,10 @@
   </div>
 {% endblock %}
 {% block extra_body %}
-  <div id="scan-overlay"><div class="box">⏳ Running scan…</div></div>
+  <div id="scan-overlay">
+    <div class="box">
+      <div id="progress-bar"><div id="progress-fill"></div></div>
+      <div id="progress-text">0%</div>
+    </div>
+  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show progress bar overlay during scans with 0-100% indicator
- add styles and JavaScript to animate progress bar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf1d7b30fc83298724466a70576604