### PR TITLE
Use FastAPI static URL helper

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 {% block title %}Pattern Finder — Scanner{% endblock %}
 {% block head_extra %}
   <script src="https://unpkg.com/htmx.org@1.9.9/dist/htmx.min.js" defer></script>
-  <script src="/static/js/scanner.js" defer></script>
+  <script src="{{ url_for('static', path='js/scanner.js') }}" defer></script>
 {% endblock %}
 {% block content %}
   <div class="card">


### PR DESCRIPTION
## Summary
- Use FastAPI's `url_for` to reference `scanner.js` so assets resolve in production

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf24fffc808329bcaf33a49357069a