### PR TITLE
feat: batch price fetching with caching and retries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,13 @@ fastapi
 uvicorn
 pandas
 numpy
-yfinance
+yfinance>=0.2.52
 ta
 scikit-learn
 Jinja2
 certifi
 python-multipart
 pytest
-httpx
+httpx[http2]>=0.27.0
 uvloop
+pyarrow>=15.0.0

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -17,7 +17,7 @@ from fastapi.templating import Jinja2Templates
 
 from indices import SP100, TOP150, TOP250
 from db import DB_PATH, get_db, get_settings
-from scanner import compute_scan_for_ticker
+from scanner import compute_scan_for_ticker, preload_prices
 from utils import now_et, TZ
 
 router = APIRouter()
@@ -488,6 +488,7 @@ async def scanner_run(request: Request):
 
     # Run the scan using a global executor.  Reusing the pool avoids the
     # overhead of spawning fresh workers for every request.
+    preload_prices(tickers, params.get("interval", "15m"), params.get("lookback_years", 2.0))
     rows = []
     ex = _get_scan_executor()
     future_to_ticker = {ex.submit(compute_scan_for_ticker, t, params): t for t in tickers}

--- a/scheduler.py
+++ b/scheduler.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Callable, Dict, Any
 
 from db import DB_PATH, get_settings, set_last_run
+from scanner import preload_prices
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,7 @@ async def favorites_loop(market_is_open: Callable[[datetime], bool], now_et: Cal
                             atrz_gate=0.10,
                             slope_gate_pct=0.02,
                         )
+                        preload_prices([f["ticker"] for f in favs], params.get("interval", "15m"), params.get("lookback_years", 2.0))
                         hits = []
                         for f in favs:
                             row = compute_scan_for_ticker(f["ticker"], params)

--- a/services/data_fetcher.py
+++ b/services/data_fetcher.py
@@ -1,0 +1,145 @@
+import os
+import math
+import time
+import logging
+from pathlib import Path
+from typing import List, Dict
+
+import pandas as pd
+import yfinance as yf
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = int(os.getenv("PF_BATCH_SIZE", "25"))
+TTL_INTRADAY = int(os.getenv("PF_TTL_INTRADAY", "300"))
+TTL_DAILY = int(os.getenv("PF_TTL_DAILY", "3600"))
+MAX_RETRIES = int(os.getenv("PF_MAX_RETRIES", "5"))
+PER_TICKER_SLEEP = float(os.getenv("PF_PER_TICKER_SLEEP", "0.0"))
+
+CACHE_DIR = Path(".cache/prices")
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+INTRADAY_INTERVALS = {"1m", "2m", "5m", "15m", "30m", "60m", "90m"}
+INTRADAY_CAPS = {
+    "1m": "7d",
+    "2m": "60d",
+    "5m": "60d",
+    "15m": "60d",
+    "30m": "60d",
+    "60m": "730d",
+    "90m": "60d",
+}
+
+
+def _period_for(interval: str, lookback_years: float) -> str:
+    if interval in INTRADAY_CAPS:
+        return INTRADAY_CAPS[interval]
+    years = max(1, int(math.ceil(lookback_years)))
+    return f"{years}y"
+
+
+def _cache_file(ticker: str, interval: str, period: str) -> Path:
+    fname = f"{ticker}__{interval}__{period}.parquet"
+    return CACHE_DIR / fname
+
+
+def _cache_ttl(interval: str) -> int:
+    return TTL_INTRADAY if interval in INTRADAY_INTERVALS else TTL_DAILY
+
+
+def _is_fresh(path: Path, ttl: int) -> bool:
+    return path.exists() and (time.time() - path.stat().st_mtime) < ttl
+
+
+def _ensure_utc(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return df
+    if df.index.tz is None:
+        df.index = df.index.tz_localize("UTC")
+    else:
+        df.index = df.index.tz_convert("UTC")
+    return df
+
+
+def _download_batch(batch: List[str], period: str, interval: str) -> Dict[str, pd.DataFrame]:
+    out: Dict[str, pd.DataFrame] = {}
+    attempt = 0
+    while batch and attempt < MAX_RETRIES:
+        attempt += 1
+        logger.info("batch_size=%d attempt=%d", len(batch), attempt)
+        try:
+            data = yf.download(
+                tickers=batch,
+                period=period,
+                interval=interval,
+                group_by="ticker",
+                threads=False,
+                progress=False,
+            )
+            if isinstance(data, pd.DataFrame) and len(batch) == 1:
+                data = {batch[0]: data}
+            for t in batch:
+                df = data.get(t, pd.DataFrame()) if isinstance(data, dict) else data[t]
+                df = _ensure_utc(df)
+                out[t] = df
+            break
+        except Exception as e:  # network errors
+            code = getattr(getattr(e, "response", None), "status_code", None)
+            retry_after = (
+                getattr(getattr(e, "response", None), "headers", {}).get("Retry-After")
+                if hasattr(e, "response")
+                else None
+            )
+            wait = int(retry_after) if retry_after else 2 ** (attempt - 1)
+            logger.info("backoff=%s wait=%ds", code or "error", wait)
+            time.sleep(wait)
+            if code == 429 and len(batch) > 1:
+                half = max(1, len(batch) // 2)
+                first = batch[:half]
+                second = batch[half:]
+                out.update(_download_batch(first, period, interval))
+                batch = second
+                attempt = 0
+            if len(batch) == 1 and PER_TICKER_SLEEP > 0:
+                time.sleep(PER_TICKER_SLEEP)
+    for t in batch:
+        out.setdefault(t, pd.DataFrame())
+    return out
+
+
+def fetch_prices(tickers: List[str], interval: str, lookback_years: float) -> Dict[str, pd.DataFrame]:
+    """Fetch price data for tickers with batching, caching, and retries."""
+    period = _period_for(interval, lookback_years)
+    ttl = _cache_ttl(interval)
+    results: Dict[str, pd.DataFrame] = {}
+    to_download: List[str] = []
+
+    for t in tickers:
+        path = _cache_file(t, interval, period)
+        if _is_fresh(path, ttl):
+            try:
+                df = pd.read_parquet(path)
+                results[t] = _ensure_utc(df)
+                logger.info("cache_hit=%s", t)
+            except Exception:
+                logger.info("cache_miss=%s", t)
+                to_download.append(t)
+        else:
+            logger.info("cache_miss=%s", t)
+            to_download.append(t)
+
+    for i in range(0, len(to_download), BATCH_SIZE):
+        batch = to_download[i : i + BATCH_SIZE]
+        fetched = _download_batch(batch, period, interval)
+        for t, df in fetched.items():
+            results[t] = df
+            path = _cache_file(t, interval, period)
+            try:
+                df.to_parquet(path)
+            except Exception:
+                pass
+
+    for t in tickers:
+        results.setdefault(t, pd.DataFrame())
+    logger.info("fetched=%d cache=%d", len(to_download), len(tickers) - len(to_download))
+    return results


### PR DESCRIPTION
## Summary
- add `services.data_fetcher.fetch_prices` batching Yahoo downloads, filesystem caching, and retry/backoff logic
- preload prices before scans and reuse them via `_pfa._download_prices` hook
- wire batching into routes and scheduler
- declare yfinance/httpx/pyarrow dependencies

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement httpx>=0.27.0)*
- `python - <<'PY'
import logging, time
from services.data_fetcher import fetch_prices
logging.basicConfig(level=logging.INFO)
start=time.time(); fetch_prices(["AAPL","MSFT","TSLA"], "15m", 0.2); first=time.time()-start
start=time.time(); fetch_prices(["AAPL","MSFT","TSLA"], "15m", 0.2); second=time.time()-start
print(first, second)
PY` *(proxy errors fetching data)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfa858108083298cb943b61d3c8b9e