### PR TITLE
Use Eastern Time throughout

### DIFF
--- a/pattern_finder_app.py
+++ b/pattern_finder_app.py
@@ -34,6 +34,8 @@ import httpx
 
 from email.message import EmailMessage
 from datetime import datetime, timedelta
+
+from utils import now_et
 import smtplib, ssl, certifi
 
 from ta.momentum import RSIIndicator
@@ -1484,7 +1486,7 @@ class App:
 
     def _compose_alert_email(self, rows):
         lines = []
-        hdr = f"PatternFinder Alerts — {datetime.now().strftime('%Y-%m-%d %H:%M')}"
+        hdr = f"PatternFinder Alerts — {now_et().strftime('%Y-%m-%d %H:%M')}"
         lines.append(hdr)
         lines.append("="*len(hdr))
         any_yes = False
@@ -1540,7 +1542,7 @@ class App:
 
             # Dedupe: don't email same (ticker,interval,dir) more than once per day
             sent = self._load_sent_map()
-            today = datetime.now().strftime("%Y-%m-%d")
+            today = now_et().strftime("%Y-%m-%d")
             already = set(sent.get(today, []))
             filtered = []
             for r in rows:
@@ -1572,7 +1574,7 @@ class App:
             hh, mm = [int(x) for x in hhmm.split(":")]
         except:
             hh, mm = 9, 28
-        now = datetime.now()
+        now = now_et()
         target = now.replace(hour=hh, minute=mm, second=0, microsecond=0)
         if target <= now:
             target += timedelta(days=1)

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -535,7 +535,7 @@ async def scanner_run(request: Request):
     ctx = {
         "request": request,
         "rows": rows,
-        "ran_at": datetime.now().strftime("%I:%M:%S %p").lstrip("0"),
+        "ran_at": now_et().strftime("%I:%M:%S %p").lstrip("0"),
         "note": f"{scan_type} • {params.get('interval')} • {params.get('direction')} • window {params.get('window_value')} {params.get('window_unit')}"
     }
 
@@ -695,7 +695,7 @@ def scanner_parity(request: Request):
         {
             "request": request,
             "rows": _sort_rows(rows, sort_key),
-            "ran_at": datetime.now().strftime("%Y-%m-%d %H:%M"),
+            "ran_at": now_et().strftime("%Y-%m-%d %H:%M"),
             "note": f"TOP150 parity run • kept {len(rows)}",
         },
     )


### PR DESCRIPTION
## Summary
- ensure program timestamps use Eastern Time by relying on `now_et`
- update routes and pattern finder alerts to generate times in America/New_York

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfb02728c883299a113dfb0da643d5