### PR TITLE
Show scan rules on archived results

### DIFF
--- a/tests/test_rules_summary.py
+++ b/tests/test_rules_summary.py
@@ -1,0 +1,16 @@
+from routes import _format_rule_summary
+
+
+def test_format_rule_summary_includes_key_params():
+    params = {
+        'target_pct': 1.0,
+        'stop_pct': 0.5,
+        'max_tt_bars': 5,
+        'scan_min_hit': 60,
+        'vega_scale': 0.03,
+    }
+    summary = _format_rule_summary(params)
+    assert 'MaxBars 5' in summary
+    assert 'MinHit% 60%' in summary
+    assert 'Vega 0.03' in summary
+


### PR DESCRIPTION
## Summary
- List key scan parameters (target/stop, max bars, hit %, vega, etc.) in archived result headers
- Test rule summary formatting for expected fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfb252eee08329adfa2ddb43e0b781