### PR TITLE
Persist favorites scan snapshots and forward metrics

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -128,6 +128,15 @@ button, .btn {
   line-height:1;
 }
 
+.badge {
+  background:#1e1e1e;
+  color:var(--muted);
+  border-radius:4px;
+  padding:2px 4px;
+  font-size:.75rem;
+  display:inline-block;
+}
+
 .linklike {
   border:0;
   background:transparent;

--- a/static/js/scanner.js
+++ b/static/js/scanner.js
@@ -43,12 +43,28 @@
 
   async function addFavoriteFromRow(tr){
     if(!tr){ showToast('No row selected', false); return; }
-    const payload = {
+    const form = document.getElementById('scan-form');
+    const params = {};
+    if(form){
+      const fd = new FormData(form);
+      for(const [k,v] of fd.entries()) params[k]=v;
+    }
+    const payload = Object.assign({}, params, {
       ticker: tr.dataset.tkr || '',
       direction: (tr.dataset.dir || 'UP').toUpperCase(),
       rule: tr.dataset.rule || '',
-      interval: document.querySelector('select[name="interval"]')?.value || '15m'
-    };
+      roi_snapshot: parseFloat(tr.dataset.roi || '0'),
+      hit_snapshot: parseFloat(tr.dataset.hit || '0'),
+      dd_snapshot: parseFloat(tr.dataset.dd || '0')
+    });
+    // Map form param names to DB column names
+    if(params.delta_assumed !== undefined) payload.delta = params.delta_assumed;
+    if(params.theta_per_day_pct !== undefined) payload.theta_day = params.theta_per_day_pct;
+    if(params.atrz_gate !== undefined) payload.atrz = params.atrz_gate;
+    if(params.slope_gate_pct !== undefined) payload.slope = params.slope_gate_pct;
+    if(params.regime_trend_only !== undefined) payload.trend_only = params.regime_trend_only;
+    payload.interval = params.interval || payload.interval || '15m';
+    payload.scan_type = params.scan_type || payload.scan_type;
     if(!payload.ticker || !payload.rule){
       showToast('Missing ticker or rule', false);
       return;

--- a/templates/favorites.html
+++ b/templates/favorites.html
@@ -19,6 +19,8 @@
           <th>ROI%</th>
           <th>Hit%</th>
           <th>DD%</th>
+          <th>Snapshot At</th>
+          <th>Forward (latest)</th>
           <th>Rule</th>
           <th></th>
         </tr>
@@ -30,9 +32,15 @@
           <td><strong>{{ f["ticker"] }}</strong></td>
           <td>{{ f["direction"] }}</td>
           <td>{{ f["interval"] }}</td>
-          <td>{{ '{:.0f}'.format(f['avg_roi_pct']*100 if f['avg_roi_pct'] is not none and f['avg_roi_pct'] <= 1 else f['avg_roi_pct']) if f['avg_roi_pct'] is not none else '' }}</td>
-          <td>{{ '{:.1f}'.format(f['hit_pct']) if f['hit_pct'] is not none else '' }}</td>
-          <td>{{ '{:.0f}'.format(f['avg_dd_pct']*100 if f['avg_dd_pct'] is not none and f['avg_dd_pct'] <= 1 else f['avg_dd_pct']) if f['avg_dd_pct'] is not none else '' }}</td>
+          <td>{{ '{:.0f}'.format(f['roi_snapshot']*100 if f['roi_snapshot'] is not none and f['roi_snapshot'] <= 1 else f['roi_snapshot']) if f['roi_snapshot'] is not none else '' }}</td>
+          <td>{{ '{:.1f}'.format(f['hit_snapshot']) if f['hit_snapshot'] is not none else '' }}</td>
+          <td>{{ '{:.0f}'.format(f['dd_snapshot']*100 if f['dd_snapshot'] is not none and f['dd_snapshot'] <= 1 else f['dd_snapshot']) if f['dd_snapshot'] is not none else '' }}</td>
+          <td>{{ f['snapshot_at'][:16] if f['snapshot_at'] else '' }}</td>
+          <td>
+            {% if f['forward_roi_pct'] is not none %}
+            <span class="badge">Forward ROI {{ '{:.0f}'.format(f['forward_roi_pct']*100 if f['forward_roi_pct'] <= 1 else f['forward_roi_pct']) }} | Hit {{ '{:.1f}'.format(f['forward_hit_pct']) }} | DD {{ '{:.0f}'.format(f['forward_dd_pct']*100 if f['forward_dd_pct'] <= 1 else f['forward_dd_pct']) }}</span>
+            {% endif %}
+          </td>
           <td><code>{{ f["rule"] }}</code></td>
           <td>
             <form method="post" action="/favorites/delete/{{ f['id'] }}" style="margin:0;">

--- a/templates/results.html
+++ b/templates/results.html
@@ -60,8 +60,9 @@
   const addBtn = document.getElementById('ctx-add-fav');
   const toast = document.getElementById('toast');
   const archiveBtn = document.getElementById('btn-archive');
+  const scanParams = {{ params|tojson }};
 
-  let ctxPayload = null; // {ticker, direction, rule}
+  let ctxPayload = null;
 
   function showMenu(x, y) {
     menu.style.left = x + 'px';
@@ -101,15 +102,27 @@
   }
 
   // --- Right-click handler on table rows (event delegation) ---
+  function buildPayload(tr){
+    const p = Object.assign({}, scanParams);
+    p.ticker = tr.dataset.tkr || '';
+    p.direction = (tr.dataset.dir || 'UP').toUpperCase();
+    p.rule = tr.dataset.rule || '';
+    p.roi_snapshot = parseFloat(tr.dataset.roi || '0');
+    p.hit_snapshot = parseFloat(tr.dataset.hit || '0');
+    p.dd_snapshot = parseFloat(tr.dataset.dd || '0');
+    if(p.delta_assumed !== undefined) p.delta = p.delta_assumed;
+    if(p.theta_per_day_pct !== undefined) p.theta_day = p.theta_per_day_pct;
+    if(p.atrz_gate !== undefined) p.atrz = p.atrz_gate;
+    if(p.slope_gate_pct !== undefined) p.slope = p.slope_gate_pct;
+    if(p.regime_trend_only !== undefined) p.trend_only = p.regime_trend_only;
+    return p;
+  }
+
   document.addEventListener('contextmenu', function(e) {
     const tr = e.target?.closest('tr.row-hover');
     if (!tr || !tbl?.contains(tr)) return;
     e.preventDefault();
-    ctxPayload = {
-      ticker: tr.dataset.tkr || '',
-      direction: (tr.dataset.dir || 'UP').toUpperCase(),
-      rule: tr.dataset.rule || ''
-    };
+    ctxPayload = buildPayload(tr);
     showMenu(e.clientX, e.clientY);
   });
 
@@ -123,12 +136,7 @@
   tbl?.addEventListener('click', function(e){
     const tr = e.target?.closest('tr.row-hover');
     if (!tr || !tbl.contains(tr)) return;
-    const payload = {
-      ticker: tr.dataset.tkr || '',
-      direction: (tr.dataset.dir || 'UP').toUpperCase(),
-      rule: tr.dataset.rule || ''
-    };
-    addFavorite(payload);
+    addFavorite(buildPayload(tr));
   });
 
   // --- Add to favorites via context menu button ---


### PR DESCRIPTION
## Summary
- capture ROI/Hit/DD and scan parameters when adding a favorite and store immutable snapshot
- show snapshot values and latest forward-test badge on Favorites page
- migrate database with snapshot fields and backfill existing favorites

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfb50a3e148329b89d9376616d1abd