### PR TITLE
Implement forward test tracking

### DIFF
--- a/db.py
+++ b/db.py
@@ -55,15 +55,27 @@ SCHEMA = [
         ref_avg_dd REAL
     );
     """,
-    # Forward test results
+    # Forward test tracking
     """
     CREATE TABLE IF NOT EXISTS forward_tests (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         fav_id INTEGER NOT NULL,
-        ran_at TEXT,
-        avg_roi_pct REAL,
+        ticker TEXT NOT NULL,
+        direction TEXT NOT NULL,
+        interval TEXT NOT NULL,
+        rule TEXT,
+        entry_ts TEXT NOT NULL,
+        entry_price REAL NOT NULL,
+        target_pct REAL NOT NULL,
+        stop_pct REAL NOT NULL,
+        window_minutes INTEGER NOT NULL,
+        status TEXT NOT NULL DEFAULT 'OPEN',
+        roi_pct REAL NOT NULL DEFAULT 0.0,
+        mfe_pct REAL NOT NULL DEFAULT 0.0,
+        mae_pct REAL NOT NULL DEFAULT 0.0,
         hit_pct REAL,
-        avg_dd_pct REAL,
+        dd_pct REAL NOT NULL DEFAULT 0.0,
+        updated_at TEXT,
         FOREIGN KEY(fav_id) REFERENCES favorites(id)
     );
     """,

--- a/templates/forward.html
+++ b/templates/forward.html
@@ -14,7 +14,8 @@
           <th>ROI%</th>
           <th>Hit%</th>
           <th>DD%</th>
-          <th>Last Run</th>
+          <th>Status</th>
+          <th>Start</th>
           <th>Rule</th>
           <th></th>
         </tr>
@@ -22,17 +23,18 @@
       <tbody>
         {% for f in tests %}
         <tr>
-          <td>{{ f["id"] }}</td>
+          <td>{{ f["ft_id"] }}</td>
           <td><strong>{{ f["ticker"] }}</strong></td>
           <td>{{ f["direction"] }}</td>
           <td>{{ f["interval"] }}</td>
-          <td>{{ '{:.0f}'.format(f['avg_roi_pct']*100 if f['avg_roi_pct'] is not none and f['avg_roi_pct'] <= 1 else f['avg_roi_pct']) if f['avg_roi_pct'] is not none else '' }}</td>
-          <td>{{ '{:.1f}'.format(f['hit_pct']) if f['hit_pct'] is not none else '' }}</td>
-          <td>{{ '{:.0f}'.format(f['avg_dd_pct']*100 if f['avg_dd_pct'] is not none and f['avg_dd_pct'] <= 1 else f['avg_dd_pct']) if f['avg_dd_pct'] is not none else '' }}</td>
-          <td>{{ f["ran_at"][:16] if f["ran_at"] else '' }}</td>
+          <td>{{ '{:.1f}'.format(f['roi_pct']) if f['roi_pct'] is not none else '' }}</td>
+          <td>{{ '{:.0f}'.format(f['hit_pct']) if f['hit_pct'] is not none else '' }}</td>
+          <td>{{ '{:.1f}'.format(f['dd_pct']) if f['dd_pct'] is not none else '' }}</td>
+          <td>{{ f['status'] }}</td>
+          <td>{{ f["entry_ts"][:16] if f["entry_ts"] else '' }}</td>
           <td><code>{{ f["rule"] }}</code></td>
           <td>
-            <form method="post" action="/favorites/delete/{{ f['id'] }}" style="margin:0;">
+            <form method="post" action="/favorites/delete/{{ f['fav_id'] }}" style="margin:0;">
               <button type="submit" class="del-btn">&#10005;</button>
             </form>
           </td>

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -2,7 +2,9 @@ import sqlite3
 import sys
 from pathlib import Path
 
+import pandas as pd
 from starlette.requests import Request
+from pytest import approx
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -11,21 +13,38 @@ from routes import forward_page
 import routes
 
 
-def test_forward_page_runs_scan_and_records(tmp_path, monkeypatch):
+def test_forward_tracking_only_future_bars(tmp_path, monkeypatch):
     db.DB_PATH = str(tmp_path / "test.db")
     db.init_db()
     conn = sqlite3.connect(db.DB_PATH)
     conn.row_factory = sqlite3.Row
     cur = conn.cursor()
     cur.execute(
-        "INSERT INTO favorites(ticker, direction, interval, rule) VALUES ('AAA','UP','15m','r1')"
+        "INSERT INTO favorites(ticker, direction, interval, rule, target_pct, stop_pct, window_value, window_unit) "
+        "VALUES ('AAA','UP','15m','r1',1.0,1.0,1,'Hours')"
     )
     conn.commit()
 
-    def fake_scan(ticker, params):
-        return {"avg_roi_pct": 0.5, "hit_pct": 60.0, "avg_dd_pct": 0.1}
+    # compute_scan_for_ticker should not run
+    monkeypatch.setattr(
+        routes,
+        "compute_scan_for_ticker",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("scan should not run")),
+    )
 
-    monkeypatch.setattr(routes, "compute_scan_for_ticker", fake_scan)
+    ts0 = pd.Timestamp("2024-01-01 10:00:00", tz="UTC")
+    ts1 = pd.Timestamp("2024-01-01 10:15:00", tz="UTC")
+    df_create = pd.DataFrame({"Close": [100.0]}, index=[ts0])
+    df_update = pd.DataFrame({"Close": [100.0, 102.0]}, index=[ts0, ts1])
+    calls = {"n": 0}
+
+    def fake_fetch_prices(tickers, interval, lookback_years):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            return {tickers[0]: df_create}
+        return {tickers[0]: df_update}
+
+    monkeypatch.setattr(routes, "fetch_prices", fake_fetch_prices)
 
     class DummyResponse:
         def __init__(self, name, context):
@@ -38,8 +57,17 @@ def test_forward_page_runs_scan_and_records(tmp_path, monkeypatch):
     monkeypatch.setattr(routes.templates, "TemplateResponse", dummy_template_response)
 
     request = Request({"type": "http"})
-    resp = forward_page(request, db=cur)
-    assert resp.template.name == "forward.html"
-    cur.execute("SELECT COUNT(*) FROM forward_tests")
-    assert cur.fetchone()[0] == 1
+    forward_page(request, db=cur)
+    cur.execute("SELECT roi_pct, status FROM forward_tests")
+    row = cur.fetchone()
+    assert row["roi_pct"] == 0.0
+    assert row["status"] == "OPEN"
+
+    forward_page(request, db=cur)
+    cur.execute("SELECT roi_pct, status, hit_pct, dd_pct FROM forward_tests")
+    row = cur.fetchone()
+    assert row["roi_pct"] == approx(2.0)
+    assert row["status"] == "HIT"
+    assert row["hit_pct"] == 100.0
+    assert row["dd_pct"] == 0.0
     conn.close()


### PR DESCRIPTION
## Summary
- persist snapshot-based forward tests with ROI/MFE/MAE evolution
- add forward test creation and evaluation helpers
- display forward tracking results in Forward Test tab and test forward tracking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bfb3e971f883298a0fe08b5ab10431