### PR TITLE
Add health and metrics endpoints with scan instrumentation

### DIFF
--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -1,0 +1,47 @@
+CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+
+_metrics = {}
+
+
+class Counter:
+    def __init__(self, name: str, documentation: str):
+        self.name = name
+        self.documentation = documentation
+        self.value = 0
+        _metrics[name] = self
+
+    def inc(self, amount: float = 1.0) -> None:
+        self.value += amount
+
+    def _render(self) -> str:
+        return (
+            f"# HELP {self.name} {self.documentation}\n"
+            f"# TYPE {self.name} counter\n"
+            f"{self.name} {self.value}\n"
+        )
+
+
+class Histogram:
+    def __init__(self, name: str, documentation: str):
+        self.name = name
+        self.documentation = documentation
+        self.samples = []
+        _metrics[name] = self
+
+    def observe(self, value: float) -> None:
+        self.samples.append(value)
+
+    def _render(self) -> str:
+        count = len(self.samples)
+        total = sum(self.samples)
+        return (
+            f"# HELP {self.name} {self.documentation}\n"
+            f"# TYPE {self.name} histogram\n"
+            f"{self.name}_count {count}\n"
+            f"{self.name}_sum {total}\n"
+        )
+
+
+def generate_latest() -> bytes:
+    out = "".join(metric._render() for metric in _metrics.values())
+    return out.encode("utf-8")

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytest
 httpx[http2]>=0.27.0
 uvloop
 pyarrow>=15.0.0
+prometheus-client

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -11,9 +11,11 @@ from email.message import EmailMessage
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
 
 import certifi
-from fastapi import APIRouter, Request, Form, Depends
+import time
+from fastapi import APIRouter, Request, Form, Depends, Response
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
+from prometheus_client import Counter, Histogram, CONTENT_TYPE_LATEST, generate_latest
 
 from indices import SP100, TOP150, TOP250
 from db import DB_PATH, get_db, get_settings
@@ -23,6 +25,19 @@ from utils import now_et, TZ
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
 logger = logging.getLogger(__name__)
+
+scan_duration = Histogram("scan_duration_seconds", "Duration of /scanner/run requests")
+scan_tickers = Counter("scan_tickers_total", "Tickers processed by /scanner/run")
+
+
+@router.get("/healthz")
+def healthz() -> dict:
+    return {"status": "ok"}
+
+
+@router.get("/metrics")
+def metrics() -> Response:
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 
 _scan_executor: Optional[Union[ThreadPoolExecutor, ProcessPoolExecutor]] = None
@@ -488,6 +503,7 @@ async def scanner_run(request: Request):
 
     # Run the scan using a global executor.  Reusing the pool avoids the
     # overhead of spawning fresh workers for every request.
+    start = time.perf_counter()
     preload_prices(tickers, params.get("interval", "15m"), params.get("lookback_years", 2.0))
     rows = []
     ex = _get_scan_executor()
@@ -531,6 +547,19 @@ async def scanner_run(request: Request):
             ),
             reverse=True,
         )
+
+    duration = time.perf_counter() - start
+    scan_duration.observe(duration)
+    scan_tickers.inc(len(tickers))
+    if duration > 0:
+        logger.info(
+            "scan completed: %d tickers in %.2fs (%.2f tickers/sec)",
+            len(tickers),
+            duration,
+            len(tickers) / duration,
+        )
+    else:
+        logger.info("scan completed: %d tickers in %.2fs", len(tickers), duration)
 
     ctx = {
         "request": request,

--- a/tests/test_health_metrics.py
+++ b/tests/test_health_metrics.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from routes import healthz, metrics
+
+
+def test_health_endpoint():
+    assert healthz() == {"status": "ok"}
+
+
+def test_metrics_endpoint():
+    resp = metrics()
+    assert resp.media_type.startswith("text/plain")
+    assert b"scan_duration_seconds" in resp.body


### PR DESCRIPTION
## Summary
- add `/healthz` and `/metrics` endpoints
- record scan durations and throughput using Prometheus-style counters
- include lightweight Prometheus client stub and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfb64434b483299b6dc582b768338e