### PR TITLE
Store favorite drawdown snapshot and improve scheduler

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -426,13 +426,21 @@ async def favorites_add(request: Request, db=Depends(get_db)):
     t = (payload.get("ticker") or "").strip().upper()
     rule = payload.get("rule") or ""
     direction = (payload.get("direction") or "UP").strip().upper()
+    interval = (payload.get("interval") or "15m").strip()
+    ref_dd = payload.get("ref_avg_dd")
+    try:
+        ref_dd = float(ref_dd)
+        if ref_dd > 1:
+            ref_dd /= 100.0
+    except (TypeError, ValueError):
+        ref_dd = None
 
     if not t or not rule:
         return JSONResponse({"ok": False, "error": "missing ticker or rule"}, status_code=400)
 
     db.execute(
-        "INSERT INTO favorites(ticker, direction, interval, rule) VALUES (?, ?, '15m', ?)",
-        (t, direction, rule),
+        "INSERT INTO favorites(ticker, direction, interval, rule, ref_avg_dd) VALUES (?, ?, ?, ?, ?)",
+        (t, direction, interval, rule, ref_dd),
     )
     db.connection.commit()
     return {"ok": True}

--- a/scheduler.py
+++ b/scheduler.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 async def favorites_loop(market_is_open: Callable[[datetime], bool], now_et: Callable[[], datetime], compute_scan_for_ticker: Callable[[str, Dict[str, Any]], Dict[str, Any]]):
     logger.info("scheduler started")
     while True:
+        start = asyncio.get_event_loop().time()
         try:
             ts = now_et()
             if market_is_open(ts):
@@ -51,10 +52,10 @@ async def favorites_loop(market_is_open: Callable[[datetime], bool], now_et: Cal
                         # TODO: email YES hits in a readable format
                         # TODO: archive favorites 15m scan results only if there are YES hits
                         set_last_run(boundary.isoformat(), db)
-            await asyncio.sleep(60)
         except Exception as e:
             logger.error("scheduler error: %r", e)
-            await asyncio.sleep(60)
+        elapsed = asyncio.get_event_loop().time() - start
+        await asyncio.sleep(max(0, 60 - elapsed))
 
 
 def setup_scheduler(app, market_is_open, now_et, compute_scan_for_ticker):

--- a/static/js/scanner.js
+++ b/static/js/scanner.js
@@ -49,7 +49,8 @@
       ticker: tr.dataset.tkr || '',
       direction: (tr.dataset.dir || 'UP').toUpperCase(),
       rule: tr.dataset.rule || '',
-      interval: document.querySelector('select[name="interval"]')?.value || '15m'
+      interval: document.querySelector('select[name="interval"]')?.value || '15m',
+      ref_avg_dd: parseFloat(tr.dataset.dd || '0')
     };
     if(!payload.ticker || !payload.rule){
       showToast('Missing ticker or rule', false);

--- a/templates/results.html
+++ b/templates/results.html
@@ -108,7 +108,8 @@
     ctxPayload = {
       ticker: tr.dataset.tkr || '',
       direction: (tr.dataset.dir || 'UP').toUpperCase(),
-      rule: tr.dataset.rule || ''
+      rule: tr.dataset.rule || '',
+      ref_avg_dd: parseFloat(tr.dataset.dd || '0')
     };
     showMenu(e.clientX, e.clientY);
   });
@@ -126,7 +127,8 @@
     const payload = {
       ticker: tr.dataset.tkr || '',
       direction: (tr.dataset.dir || 'UP').toUpperCase(),
-      rule: tr.dataset.rule || ''
+      rule: tr.dataset.rule || '',
+      ref_avg_dd: parseFloat(tr.dataset.dd || '0')
     };
     addFavorite(payload);
   });

--- a/tests/test_favorites.py
+++ b/tests/test_favorites.py
@@ -2,9 +2,13 @@ import sqlite3
 import sys
 from pathlib import Path
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import db
+import routes
 from routes import favorites_delete_duplicates
 
 
@@ -30,5 +34,28 @@ def test_delete_duplicates(tmp_path):
     cur.execute("SELECT COUNT(*) FROM favorites")
     count = cur.fetchone()[0]
     assert count == 2
+    conn.close()
+
+
+def test_add_favorite_ref_avg_dd(tmp_path):
+    db.DB_PATH = str(tmp_path / "test.db")
+    db.init_db()
+
+    app = FastAPI()
+    app.include_router(routes.router)
+    client = TestClient(app)
+
+    res = client.post(
+        "/favorites/add",
+        json={"ticker": "AAA", "direction": "UP", "rule": "r1", "ref_avg_dd": 5.0},
+    )
+    assert res.status_code == 200
+    assert res.json()["ok"]
+
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT ref_avg_dd FROM favorites WHERE ticker='AAA'")
+    val = cur.fetchone()[0]
+    assert val == 0.05
     conn.close()
 


### PR DESCRIPTION
## Summary
- Include reference average drawdown when adding favorites via UI or API
- Adjust scheduler loop to maintain ~60s cadence per run
- Add regression test for favorite drawdown snapshot persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfbb2f6acc83298aae744ff933094e