### PR TITLE
Implement real-time scanner progress tracking

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -218,5 +218,11 @@ button, .btn {
   text-align:center;
 }
 
+#progress-status {
+  margin-top:.25rem;
+  text-align:center;
+  font-size:.9rem;
+}
+
 #scan-overlay.htmx-request { display:grid !important; }
 .htmx-request #scan-results { opacity:.4; filter:grayscale(30%); }

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,8 +7,7 @@
 {% block content %}
   <div class="card">
     <h1 style="margin:0 0 1rem 0">Scanner</h1>
-    <form id="scan-form" action="{{ url_for('scanner_run') }}" method="post"
-          hx-post="{{ url_for('scanner_run') }}" hx-target="#scan-results" hx-indicator="#scan-overlay">
+    <form id="scan-form" action="{{ url_for('scanner_run') }}" method="post">
       <div class="row">
         <div>
           <label>Scan Type</label>
@@ -139,6 +138,7 @@
     <div class="box">
       <div id="progress-bar"><div id="progress-fill"></div></div>
       <div id="progress-text">0%</div>
+      <div id="progress-status"></div>
     </div>
   </div>
 {% endblock %}

--- a/tests/test_scanner_parallel.py
+++ b/tests/test_scanner_parallel.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import sys
 from pathlib import Path
@@ -10,7 +9,8 @@ import routes
 
 def test_scanner_run_parallel_handles_errors(monkeypatch, caplog):
     monkeypatch.setenv("SCAN_WORKERS", "2")
-    monkeypatch.setattr(routes, "TOP150", ["AAA", "BAD", "CCC"])
+
+    tickers = ["AAA", "BAD", "CCC"]
 
     def fake_scan(ticker, params):
         if ticker == "BAD":
@@ -29,23 +29,8 @@ def test_scanner_run_parallel_handles_errors(monkeypatch, caplog):
 
     monkeypatch.setattr(routes, "compute_scan_for_ticker", fake_scan)
 
-    class DummyResponse:
-        def __init__(self, name, context):
-            self.template = type("T", (), {"name": name})
-            self.context = context
-
-    monkeypatch.setattr(routes.templates, "TemplateResponse", lambda name, ctx: DummyResponse(name, ctx))
-
-    class DummyRequest:
-        async def form(self):
-            return {}
-
-    req = DummyRequest()
-
     with caplog.at_level(logging.ERROR):
-        resp = asyncio.run(routes.scanner_run(req))
+        rows = routes._perform_scan(tickers, {}, "")
 
-    assert resp.template.name == "results.html"
-    rows = resp.context["rows"]
     assert {r["ticker"] for r in rows} == {"AAA", "CCC"}
     assert any("BAD" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- track scan progress server-side with task IDs, SSE progress feed, and results endpoint
- update front-end to poll progress and render results when complete
- add styles and tests for new progress tracking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bfbf00cd248329b876b3141cb404c8