### PR TITLE
Handle forward test schema and auto-migration

### DIFF
--- a/templates/forward.html
+++ b/templates/forward.html
@@ -3,6 +3,9 @@
 {% block content %}
   <div class="card">
     <h1 style="margin-top:0;">Forward Test</h1>
+    {% if error %}
+    <p class="error">{{ error }}</p>
+    {% endif %}
     {% if tests and tests|length %}
     <table class="table">
       <thead>
@@ -27,11 +30,11 @@
           <td><strong>{{ f["ticker"] }}</strong></td>
           <td>{{ f["direction"] }}</td>
           <td>{{ f["interval"] }}</td>
-          <td>{{ '{:.1f}'.format(f['roi_pct']) if f['roi_pct'] is not none else '' }}</td>
+          <td>{{ '{:.1f}'.format(f['roi']) if f['roi'] is not none else '' }}</td>
           <td>{{ '{:.0f}'.format(f['hit_pct']) if f['hit_pct'] is not none else '' }}</td>
           <td>{{ '{:.1f}'.format(f['dd_pct']) if f['dd_pct'] is not none else '' }}</td>
           <td>{{ f['status'] }}</td>
-          <td>{{ f["entry_ts"][:16] if f["entry_ts"] else '' }}</td>
+          <td>{{ f["created_at"][:16] if f["created_at"] else '' }}</td>
           <td><code>{{ f["rule"] }}</code></td>
           <td>
             <form method="post" action="/favorites/delete/{{ f['fav_id'] }}" style="margin:0;">

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -22,7 +22,7 @@ def test_forward_tests_table_exists(tmp_path):
     db.init_db()
     conn = sqlite3.connect(db.DB_PATH)
     cur = conn.cursor()
-    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='forward_tests'")
-    row = cur.fetchone()
+    cur.execute("PRAGMA table_info(forward_tests)")
+    cols = {r[1] for r in cur.fetchall()}
     conn.close()
-    assert row is not None
+    assert "status" in cols

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -58,16 +58,16 @@ def test_forward_tracking_only_future_bars(tmp_path, monkeypatch):
 
     request = Request({"type": "http"})
     forward_page(request, db=cur)
-    cur.execute("SELECT roi_pct, status FROM forward_tests")
+    cur.execute("SELECT roi, status FROM forward_tests")
     row = cur.fetchone()
-    assert row["roi_pct"] == 0.0
-    assert row["status"] == "OPEN"
+    assert row["roi"] == 0.0
+    assert row["status"] == "pending"
 
     forward_page(request, db=cur)
-    cur.execute("SELECT roi_pct, status, hit_pct, dd_pct FROM forward_tests")
+    cur.execute("SELECT roi, status, hit_pct, dd_pct FROM forward_tests")
     row = cur.fetchone()
-    assert row["roi_pct"] == approx(2.0)
-    assert row["status"] == "HIT"
+    assert row["roi"] == approx(2.0)
+    assert row["status"] == "done"
     assert row["hit_pct"] == 100.0
     assert row["dd_pct"] == 0.0
     conn.close()


### PR DESCRIPTION
## Summary
- expand `forward_tests` table with status/ROI timestamps and auto-migrate existing DBs
- update forward testing routes to use new columns, add error handling, and show friendly errors
- adjust template and tests for new forward test workflow

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bfbff950d0832983369eca71727d32