### PR TITLE
Prevent progress polling from being cached

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -732,7 +732,7 @@ async def scanner_progress(task_id: str):
         "percent": task.get("percent", 0.0),
         "state": task.get("state", "running"),
     }
-    return JSONResponse(data)
+    return JSONResponse(data, headers={"Cache-Control": "no-store"})
 
 
 @router.get("/scanner/results/{task_id}", response_class=HTMLResponse)
@@ -744,7 +744,7 @@ async def scanner_results(request: Request, task_id: str):
     ctx = task.get("ctx", {}).copy()
     ctx["request"] = request
     logger.info("task %s rendered", task_id)
-    return templates.TemplateResponse("results.html", ctx)
+    return templates.TemplateResponse("results.html", ctx, headers={"Cache-Control": "no-store"})
 
 @router.post("/runs/archive")
 async def archive_run(request: Request, db=Depends(get_db)):

--- a/static/js/scanner.js
+++ b/static/js/scanner.js
@@ -161,7 +161,7 @@
 
       const poll = async function(){
         try{
-          const res = await fetch(`/scanner/progress/${taskId}`);
+          const res = await fetch(`/scanner/progress/${taskId}`, {cache: 'no-store'});
           const data = await res.json();
           last = Date.now();
           progressFill.style.width = (data.percent || 0) + '%';
@@ -172,7 +172,7 @@
             progressFill.style.width = '100%';
             progressText.textContent = '100%';
             try{
-              const html = await fetch(`/scanner/results/${taskId}`).then(r=>{
+              const html = await fetch(`/scanner/results/${taskId}`, {cache: 'no-store'}).then(r=>{
                 if(!r.ok) throw new Error('');
                 return r.text();
               });


### PR DESCRIPTION
## Summary
- Disable HTTP caching for scanner progress/results endpoints
- Fetch progress and result updates with `cache: 'no-store'` to force revalidation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfcde5a37c83298e27a65d8300e95d