### PR TITLE
Use shared store for scan tasks

### DIFF
--- a/db.py
+++ b/db.py
@@ -109,6 +109,19 @@ SCHEMA = [
     );
     """,
     "CREATE INDEX IF NOT EXISTS idx_run_results_run ON run_results(run_id);",
+    # Scan tasks for cross-worker communication
+    """
+    CREATE TABLE IF NOT EXISTS scan_tasks (
+        id TEXT PRIMARY KEY,
+        total INTEGER,
+        done INTEGER,
+        percent REAL,
+        state TEXT,
+        message TEXT,
+        ctx TEXT,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    """,
 ]
 
 


### PR DESCRIPTION
## Summary
- Persist scan task state in new `scan_tasks` table so all workers can share progress
- Track and update scan tasks through SQLite helpers and cleanup after results retrieval
- Update scanner endpoints to use shared task storage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfd0f6f9888329b37f5179ae81efde