### PR TITLE
Add async HTTP client with rate limiting and caching

### DIFF
--- a/services/http_client.py
+++ b/services/http_client.py
@@ -1,0 +1,91 @@
+import asyncio
+import os
+import random
+import time
+from typing import Dict, Optional
+
+import httpx
+
+MAX_CONCURRENCY = int(os.getenv("HTTP_MAX_CONCURRENCY", "10"))
+MAX_RETRIES = int(os.getenv("HTTP_MAX_RETRIES", "3"))
+
+_client: Optional[httpx.AsyncClient] = None
+_semaphore = asyncio.Semaphore(MAX_CONCURRENCY)
+_rate_limiters: Dict[str, "TokenBucket"] = {}
+
+
+class TokenBucket:
+    def __init__(self, rate: float, capacity: int) -> None:
+        self.rate = rate
+        self.capacity = capacity
+        self.tokens = capacity
+        self.updated = time.monotonic()
+
+    def _add_new_tokens(self) -> None:
+        now = time.monotonic()
+        delta = now - self.updated
+        self.updated = now
+        self.tokens = min(self.capacity, self.tokens + delta * self.rate)
+
+    async def consume(self, amount: int = 1) -> None:
+        while True:
+            self._add_new_tokens()
+            if self.tokens >= amount:
+                self.tokens -= amount
+                return
+            await asyncio.sleep((amount - self.tokens) / self.rate)
+
+
+def get_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        _client = httpx.AsyncClient(
+            http2=True,
+            timeout=10.0,
+            limits=httpx.Limits(max_connections=MAX_CONCURRENCY * 4, max_keepalive_connections=MAX_CONCURRENCY * 2),
+        )
+    return _client
+
+
+def set_rate_limit(host: str, rate: float, capacity: int) -> None:
+    """Configure a token bucket rate limiter for a host."""
+    _rate_limiters[host] = TokenBucket(rate, capacity)
+
+
+async def request(method: str, url: str, **kwargs) -> httpx.Response:
+    client = get_client()
+    host = httpx.URL(url).host
+    limiter = _rate_limiters.get(host)
+    retries = 0
+    while True:
+        if limiter:
+            await limiter.consume()
+        try:
+            async with _semaphore:
+                resp = await client.request(method, url, **kwargs)
+        except httpx.RequestError:
+            resp = None
+        if resp and resp.status_code < 400:
+            return resp
+        status = resp.status_code if resp else None
+        if status and status not in (429,) and status < 500:
+            resp.raise_for_status()
+        retry_after = None
+        if resp:
+            retry_after = resp.headers.get("Retry-After")
+        if retries >= MAX_RETRIES:
+            if resp:
+                resp.raise_for_status()
+            raise httpx.RequestError("max retries exceeded", request=None)
+        wait = float(retry_after) if retry_after else (0.5 * (2 ** retries) + random.uniform(0, 0.5))
+        retries += 1
+        await asyncio.sleep(wait)
+
+
+async def get(url: str, **kwargs) -> httpx.Response:
+    return await request("GET", url, **kwargs)
+
+
+async def get_json(url: str, **kwargs):
+    resp = await get(url, **kwargs)
+    return resp.json()


### PR DESCRIPTION
## Summary
- introduce shared async HTTP client with connection pooling, concurrency control, retries and optional token bucket rate limiting
- memoize price fetches per ticker/interval/range and batch async downloads via the shared client
- scope price cache in scanner by ticker, interval and lookback years to reuse data within a scan

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bfdbd8a83083299cf856649f078f61