### PR TITLE
Persist metrics snapshots and refresh forward tests

### DIFF
--- a/static/js/scanner.js
+++ b/static/js/scanner.js
@@ -45,12 +45,23 @@
 
   async function addFavoriteFromRow(tr){
     if(!tr){ showToast('No row selected', false); return; }
+    const form = document.getElementById('scan-form');
+    const settings = {};
+    if(form){
+      const fd = new FormData(form);
+      for(const [k,v] of fd.entries()) settings[k]=v;
+    }
     const payload = {
       ticker: tr.dataset.tkr || '',
       direction: (tr.dataset.dir || 'UP').toUpperCase(),
       rule: tr.dataset.rule || '',
       interval: document.querySelector('select[name="interval"]')?.value || '15m',
-      ref_avg_dd: parseFloat(tr.dataset.dd || '0')
+      ref_avg_dd: parseFloat(tr.dataset.dd || '0'),
+      roi_snapshot: parseFloat(tr.dataset.roi || '0'),
+      hit_pct_snapshot: parseFloat(tr.dataset.hit || '0'),
+      dd_pct_snapshot: parseFloat(tr.dataset.dd || '0'),
+      rule_snapshot: tr.dataset.rule || '',
+      settings_json_snapshot: settings
     };
     if(!payload.ticker || !payload.rule){
       showToast('Missing ticker or rule', false);

--- a/templates/forward.html
+++ b/templates/forward.html
@@ -30,9 +30,9 @@
           <td><strong>{{ f["ticker"] }}</strong></td>
           <td>{{ f["direction"] }}</td>
           <td>{{ f["interval"] }}</td>
-          <td>{{ '{:.1f}'.format(f['roi']) if f['roi'] is not none else '' }}</td>
-          <td>{{ '{:.0f}'.format(f['hit_pct']) if f['hit_pct'] is not none else '' }}</td>
-          <td>{{ '{:.1f}'.format(f['dd_pct']) if f['dd_pct'] is not none else '' }}</td>
+          <td>{{ '{:.1f}'.format(f['roi_forward']) if f['roi_forward'] is not none else '' }}</td>
+          <td>{{ '{:.0f}'.format(f['hit_forward']) if f['hit_forward'] is not none else '' }}</td>
+          <td>{{ '{:.1f}'.format(f['dd_forward']) if f['dd_forward'] is not none else '' }}</td>
           <td>{{ f['status'] }}</td>
           <td>{{ f["created_at"][:16] if f["created_at"] else '' }}</td>
           <td><code>{{ f["rule"] }}</code></td>

--- a/templates/results.html
+++ b/templates/results.html
@@ -78,6 +78,16 @@
     setTimeout(() => { toast.hidden = true; }, 1800);
   }
 
+  function getSettings(){
+    const form = document.getElementById('scan-form');
+    const params = {};
+    if (form) {
+      const fd = new FormData(form);
+      for (const [k, v] of fd.entries()) params[k] = v;
+    }
+    return params;
+  }
+
   async function addFavorite(payload){
     if (!payload || !payload.ticker || !payload.rule) {
       showToast('Missing ticker or rule', false);
@@ -109,7 +119,12 @@
       ticker: tr.dataset.tkr || '',
       direction: (tr.dataset.dir || 'UP').toUpperCase(),
       rule: tr.dataset.rule || '',
-      ref_avg_dd: parseFloat(tr.dataset.dd || '0')
+      ref_avg_dd: parseFloat(tr.dataset.dd || '0'),
+      roi_snapshot: parseFloat(tr.dataset.roi || '0'),
+      hit_pct_snapshot: parseFloat(tr.dataset.hit || '0'),
+      dd_pct_snapshot: parseFloat(tr.dataset.dd || '0'),
+      rule_snapshot: tr.dataset.rule || '',
+      settings_json_snapshot: getSettings()
     };
     showMenu(e.clientX, e.clientY);
   });
@@ -128,7 +143,12 @@
       ticker: tr.dataset.tkr || '',
       direction: (tr.dataset.dir || 'UP').toUpperCase(),
       rule: tr.dataset.rule || '',
-      ref_avg_dd: parseFloat(tr.dataset.dd || '0')
+      ref_avg_dd: parseFloat(tr.dataset.dd || '0'),
+      roi_snapshot: parseFloat(tr.dataset.roi || '0'),
+      hit_pct_snapshot: parseFloat(tr.dataset.hit || '0'),
+      dd_pct_snapshot: parseFloat(tr.dataset.dd || '0'),
+      rule_snapshot: tr.dataset.rule || '',
+      settings_json_snapshot: getSettings()
     };
     addFavorite(payload);
   });

--- a/tests/test_favorites.py
+++ b/tests/test_favorites.py
@@ -10,6 +10,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import db
 import routes
 from routes import favorites_delete_duplicates
+from starlette.requests import Request
 
 
 def test_delete_duplicates(tmp_path):
@@ -57,5 +58,38 @@ def test_add_favorite_ref_avg_dd(tmp_path):
     cur.execute("SELECT ref_avg_dd FROM favorites WHERE ticker='AAA'")
     val = cur.fetchone()[0]
     assert val == 0.05
+    conn.close()
+
+
+def test_favorites_snapshot_values(tmp_path, monkeypatch):
+    db.DB_PATH = str(tmp_path / "test.db")
+    db.init_db()
+
+    conn = sqlite3.connect(db.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO favorites(ticker, direction, interval, rule, roi_snapshot, hit_pct_snapshot, dd_pct_snapshot, rule_snapshot, settings_json_snapshot, snapshot_at) VALUES ('AAA','UP','15m','r1',1.23,45.0,0.5,'rule','{}','2024-01-01')"
+    )
+    conn.commit()
+
+    monkeypatch.setattr(
+        routes,
+        "compute_scan_for_ticker",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not recompute")),
+    )
+
+    class DummyResponse:
+        def __init__(self, name, context):
+            self.template = type("T", (), {"name": name})
+            self.context = context
+
+    monkeypatch.setattr(routes.templates, "TemplateResponse", lambda name, ctx: DummyResponse(name, ctx))
+    request = Request({"type": "http"})
+    resp = routes.favorites_page(request, db=cur)
+    fav = resp.context["favorites"][0]
+    assert fav["avg_roi_pct"] == 1.23
+    assert fav["hit_pct"] == 45.0
+    assert fav["avg_dd_pct"] == 0.5
     conn.close()
 

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -58,16 +58,16 @@ def test_forward_tracking_only_future_bars(tmp_path, monkeypatch):
 
     request = Request({"type": "http"})
     forward_page(request, db=cur)
-    cur.execute("SELECT roi, status FROM forward_tests")
+    cur.execute("SELECT roi_forward, status FROM forward_tests")
     row = cur.fetchone()
-    assert row["roi"] == 0.0
-    assert row["status"] == "pending"
+    assert row["roi_forward"] == 0.0
+    assert row["status"] == "queued"
 
     forward_page(request, db=cur)
-    cur.execute("SELECT roi, status, hit_pct, dd_pct FROM forward_tests")
+    cur.execute("SELECT roi_forward, status, hit_forward, dd_forward FROM forward_tests")
     row = cur.fetchone()
-    assert row["roi"] == approx(2.0)
-    assert row["status"] == "done"
-    assert row["hit_pct"] == 100.0
-    assert row["dd_pct"] == 0.0
+    assert row["roi_forward"] == approx(2.0)
+    assert row["status"] == "ok"
+    assert row["hit_forward"] == 100.0
+    assert row["dd_forward"] == 0.0
     conn.close()


### PR DESCRIPTION
## Summary
- Persist ROI, hit%, DD, rule text, and scan settings as immutable snapshots when saving a favorite
- Overhaul forward test schema and logic to track forward ROI/Hit/DD with run bookkeeping
- Capture client scan parameters and metrics when adding favorites

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfdd430dac8329884998089ba1539d