### PR TITLE
Improve scan progress granularity

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -174,6 +174,7 @@ def _perform_scan(
     params: dict,
     sort_key: str,
     progress_cb: Optional[Callable[[int, int, str], None]] = None,
+    progress_every: int = 5,
 ) -> list[dict]:
     start = time.perf_counter()
     total = len(tickers)
@@ -183,6 +184,7 @@ def _perform_scan(
     rows: list[dict] = []
     ex = _get_scan_executor()
     future_to_ticker = {ex.submit(compute_scan_for_ticker, t, params): t for t in tickers}
+    step = max(1, int(progress_every))
     done = 0
     for fut in as_completed(future_to_ticker):
         ticker = future_to_ticker[fut]
@@ -193,7 +195,7 @@ def _perform_scan(
         except Exception as e:
             logger.error("scan failed for %s: %s", ticker, e)
         done += 1
-        if progress_cb:
+        if progress_cb and (done % step == 0 or done == total):
             progress_cb(done, total, f"Scanning {done}/{total}")
 
     try:

--- a/tests/test_progress_updates.py
+++ b/tests/test_progress_updates.py
@@ -1,0 +1,35 @@
+import routes
+from concurrent.futures import Future
+
+def test_perform_scan_progress_every(monkeypatch):
+    tickers = [f"T{i}" for i in range(12)]
+
+    # stub compute_scan_for_ticker
+    monkeypatch.setattr(routes, "compute_scan_for_ticker", lambda t, p: {"ticker": t})
+    # no-op preload
+    monkeypatch.setattr(routes, "preload_prices", lambda t, i, l: None)
+
+    class ImmediateExecutor:
+        def submit(self, fn, *args, **kwargs):
+            fut = Future()
+            try:
+                fut.set_result(fn(*args, **kwargs))
+            except Exception as e:
+                fut.set_exception(e)
+            return fut
+    monkeypatch.setattr(routes, "_get_scan_executor", lambda: ImmediateExecutor())
+
+    updates = []
+
+    def prog(d, total, msg):
+        if d:
+            updates.append(d)
+
+    routes._perform_scan(
+        tickers,
+        {},
+        "",
+        progress_cb=prog,
+        progress_every=5,
+    )
+    assert updates == [5, 10, 12]


### PR DESCRIPTION
## Summary
- Allow scanner to report progress every N tickers via new `progress_every` option
- Exercise periodic progress updates with new unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfe535f8a48329aa8a3d8227d63369