### PR TITLE
Normalize price data and handle missing data in scanner

### DIFF
--- a/pattern_finder_app.py
+++ b/pattern_finder_app.py
@@ -32,6 +32,8 @@ import numpy as np
 import yfinance as yf
 import httpx
 
+from services.price_utils import normalize_price_df, DataUnavailableError
+
 from email.message import EmailMessage
 from datetime import datetime, timedelta
 
@@ -467,6 +469,9 @@ def analyze_roi_mode(ticker, interval, direction,
                      ccp_grid=(0.0,0.0005), depth_grid=(4,5,6)):
 
     raw = _download_prices(ticker, interval, lookback_years)
+    raw = normalize_price_df(raw)
+    if raw is None:
+        raise DataUnavailableError(f"{ticker} no_close_or_empty")
     prices = raw["Close"].copy()
     X = build_features(raw, interval)
     regime = build_regime_features(X.index, interval, lookback_years)

--- a/scripts/clear_price_cache.py
+++ b/scripts/clear_price_cache.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Remove price cache parquet files created before today."""
+from __future__ import annotations
+
+from pathlib import Path
+from datetime import date
+
+CACHE_DIR = Path('.cache/prices')
+
+
+def main() -> None:
+    today = date.today()
+    removed = 0
+    if not CACHE_DIR.exists():
+        return
+    for path in CACHE_DIR.glob('*.parquet'):
+        try:
+            if date.fromtimestamp(path.stat().st_mtime) < today:
+                path.unlink()
+                removed += 1
+        except Exception:
+            continue
+    print(f"removed {removed} files")
+
+
+if __name__ == '__main__':
+    main()

--- a/services/price_utils.py
+++ b/services/price_utils.py
@@ -1,0 +1,53 @@
+"""Utilities for working with price data frames."""
+from __future__ import annotations
+
+from typing import Optional
+import pandas as pd
+
+
+class DataUnavailableError(Exception):
+    """Raised when price data is missing or unusable."""
+    pass
+
+
+# Mapping of common column variants to canonical OHLCV names.
+_CANONICAL = {
+    "open": "Open",
+    "high": "High",
+    "low": "Low",
+    "close": "Close",
+    "adjclose": "Adj Close",
+    "adj close": "Adj Close",
+    "adj_close": "Adj Close",
+    "volume": "Volume",
+}
+
+
+def normalize_price_df(df: Optional[pd.DataFrame]) -> Optional[pd.DataFrame]:
+    """Return ``df`` with canonical columns or ``None`` if unusable.
+
+    The function collapses multi-index columns, normalises common column names
+    to ``Open``, ``High``, ``Low``, ``Close``, ``Adj Close`` and ``Volume`` and
+    returns ``None`` if the frame is ``None``, empty or missing a ``Close``
+    column.
+    """
+    if df is None:
+        return None
+    if not isinstance(df, pd.DataFrame) or df.empty:
+        return None
+
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(-1)
+
+    # Standardise column names (case-insensitive)
+    rename_map = {}
+    for col in list(df.columns):
+        key = str(col).lower()
+        if key in _CANONICAL:
+            rename_map[col] = _CANONICAL[key]
+    if rename_map:
+        df = df.rename(columns=rename_map)
+
+    if "Close" not in df.columns:
+        return None
+    return df

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,15 +1,17 @@
 {% set safe_rows = rows or [] %}
+{% set skip_md = skipped_missing_data or 0 %}
 <div class="card">
   <div class="card-header" style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;">
     <strong>Results</strong>
     {% if ran_at %}<span class="muted"> at {{ ran_at }} </span>{% endif %}
     {% if note %}<span class="muted"> • {{ note }}</span>{% endif %}
+    {% if skip_md %}<span class="muted"> • skipped {{ skip_md }} missing data</span>{% endif %}
     <span style="flex:1 1 auto"></span>
     <button id="btn-archive" class="btn" title="Save this run and rows to Archive">💾 Save to Archive</button>
   </div>
 
   {% if safe_rows|length == 0 %}
-    <div class="card-body"><div class="muted">No results.</div></div>
+    <div class="card-body"><div class="muted">{% if skip_md > 0 %}All tickers were skipped due to missing data.{% else %}No results.{% endif %}</div></div>
   {% else %}
   <div class="card-body" style="overflow:auto;">
     <table class="table" id="results-table">

--- a/tests/test_scanner_integration.py
+++ b/tests/test_scanner_integration.py
@@ -36,7 +36,7 @@ def test_scanner_progress_and_results(monkeypatch):
                 "stability": 0.0,
                 "rule": "r1",
             })
-        return rows
+        return rows, 0
 
     monkeypatch.setattr(routes, "_perform_scan", fake_perform_scan)
 

--- a/tests/test_scanner_parallel.py
+++ b/tests/test_scanner_parallel.py
@@ -30,7 +30,8 @@ def test_scanner_run_parallel_handles_errors(monkeypatch, caplog):
     monkeypatch.setattr(routes, "compute_scan_for_ticker", fake_scan)
 
     with caplog.at_level(logging.ERROR):
-        rows = routes._perform_scan(tickers, {}, "")
+        rows, skipped = routes._perform_scan(tickers, {}, "")
 
     assert {r["ticker"] for r in rows} == {"AAA", "CCC"}
+    assert skipped == 0
     assert any("BAD" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add `normalize_price_df` utility and custom `DataUnavailableError`
- normalize price frames after fetch/load, track cache schema and purge on upgrade
- propagate missing data errors through scanner and surface skip counts in logs/UI
- add script to clear stale price cache

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c07c2bfbd08329a94df57807796cf4