### PR TITLE
feat: robust Yahoo Finance rate limiting and caching

### DIFF
--- a/services/http_client.py
+++ b/services/http_client.py
@@ -3,7 +3,7 @@ import os
 import random
 import time
 import logging
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple, Callable
 
 import httpx
 
@@ -18,6 +18,18 @@ MAX_RETRIES = int(os.getenv("HTTP_MAX_RETRIES", "10"))
 _client: Optional[httpx.AsyncClient] = None
 _semaphore = asyncio.Semaphore(MAX_CONCURRENCY)
 _rate_limiters: Dict[str, "TokenBucket"] = {}
+
+# Simple in-memory cache and in-flight tracking so duplicate requests coalesce
+# and short-lived results can be reused.
+_CACHE: Dict[str, Tuple[float, httpx.Response]] = {}
+_INFLIGHT: Dict[str, asyncio.Future] = {}
+CACHE_TTL = int(os.getenv("HTTP_CACHE_TTL", "90"))  # seconds
+
+# Callback used by the scanner to surface rate limiting waits to the UI.
+_wait_cb: Optional[Callable[[float], None]] = None
+
+# Track sustained 429 responses to implement a circuit breaker.
+_circuit: Dict[str, Dict[str, float]] = {}
 
 
 class TokenBucket:
@@ -58,52 +70,130 @@ def set_rate_limit(host: str, rate: float, capacity: int) -> None:
     _rate_limiters[host] = TokenBucket(rate, capacity)
 
 
+def set_wait_callback(cb: Optional[Callable[[float], None]]) -> None:
+    """Register a callback invoked before sleeping due to rate limiting.
+
+    The callback receives the number of seconds we expect to wait.  A value of 0
+    indicates that any previous wait has completed and the UI can clear any
+    rate-limit message.
+    """
+    global _wait_cb
+    _wait_cb = cb
+
+
+def clear_cache() -> None:
+    """Clear the short-lived response cache.  Mainly used in tests."""
+    _CACHE.clear()
+
+
 async def request(method: str, url: str, **kwargs) -> httpx.Response:
-    client = get_client()
-    host = httpx.URL(url).host
-    limiter = _rate_limiters.get(host)
-    retries = 0
-    while True:
-        if limiter:
-            await limiter.consume()
-        try:
-            async with _semaphore:
-                resp = await client.request(method, url, **kwargs)
-        except httpx.RequestError:
-            resp = None
-        if resp and resp.status_code < 400:
-            return resp
-        status = resp.status_code if resp else None
-        if status and status not in (429,) and status < 500:
-            resp.raise_for_status()
-        # Parse Retry-After header if provided.  Yahoo Finance typically returns
-        # an integer number of seconds, but we guard against bad values.
-        retry_after = None
-        if resp:
-            ra = resp.headers.get("Retry-After")
+    """Robust HTTP request with retries, caching, coalescing and circuit breaker."""
+
+    key = None
+    if method.upper() == "GET" and not kwargs.get("no_cache"):
+        key = f"{method}:{url}"
+        cached = _CACHE.get(key)
+        if cached and cached[0] > time.monotonic():
+            return cached[1]
+        inflight = _INFLIGHT.get(key)
+        if inflight:
+            return await inflight
+
+    async def _do_request() -> httpx.Response:
+        client = get_client()
+        host = httpx.URL(url).host
+        limiter = _rate_limiters.get(host)
+        retries = 0
+        cb_state = _circuit.setdefault(host, {"first": 0.0, "opened": 0.0})
+
+        while True:
+            now = time.monotonic()
+            opened = cb_state.get("opened", 0.0)
+            if opened > now:
+                wait = opened - now
+                if _wait_cb:
+                    _wait_cb(wait)
+                await asyncio.sleep(wait)
+                if _wait_cb:
+                    _wait_cb(0)
+
+            if limiter:
+                await limiter.consume()
+
             try:
-                retry_after = float(ra) if ra else None
-            except (TypeError, ValueError):
-                retry_after = None
-        if retries >= MAX_RETRIES:
-            if resp:
+                async with _semaphore:
+                    resp = await client.request(method, url, **kwargs)
+            except httpx.RequestError:
+                resp = None
+            if resp and resp.status_code < 400:
+                if key:
+                    _CACHE[key] = (time.monotonic() + CACHE_TTL, resp)
+                if _wait_cb:
+                    _wait_cb(0)
+                cb_state["first"] = 0.0
+                return resp
+
+            status = resp.status_code if resp else None
+            if status and status not in (429,) and status < 500:
                 resp.raise_for_status()
-            raise httpx.RequestError("max retries exceeded", request=None)
-        if status == 429:
-            # HTTP 429 indicates we are being rate limited.  Respect the server's
-            # Retry-After header when present.  Otherwise fall back to an
-            # exponential backoff starting at one second and doubling each retry
-            # up to a maximum of 64 seconds: 1, 2, 4, 8, 16, 32, 64.
-            wait = retry_after if retry_after is not None else min(64, 2 ** retries)
-            logger.warning("rate_limited host=%s wait=%.2fs", host, wait)
-        else:
-            # For other errors use an exponential backoff with a bit of jitter so
-            # concurrent callers do not stampede.
-            wait = retry_after if retry_after is not None else (
-                0.5 * (2 ** retries) + random.uniform(0, 0.5)
-            )
-        retries += 1
-        await asyncio.sleep(wait)
+
+            # Parse Retry-After header if provided.
+            retry_after = None
+            if resp:
+                ra = resp.headers.get("Retry-After")
+                try:
+                    retry_after = float(ra) if ra else None
+                except (TypeError, ValueError):
+                    retry_after = None
+
+            if retries >= MAX_RETRIES:
+                if resp:
+                    resp.raise_for_status()
+                raise httpx.RequestError("max retries exceeded", request=None)
+
+            if status == 429:
+                now = time.monotonic()
+                if cb_state["first"] == 0.0:
+                    cb_state["first"] = now
+                # Circuit breaker: if we've been continuously rate limited for
+                # more than 60s, pause outbound requests for a cool-down period.
+                if now - cb_state["first"] > 60:
+                    cooldown = random.uniform(120, 300)
+                    cb_state["opened"] = now + cooldown
+                    if _wait_cb:
+                        _wait_cb(cooldown)
+                    await asyncio.sleep(cooldown)
+                    if _wait_cb:
+                        _wait_cb(0)
+                    cb_state["first"] = 0.0
+                    retries = 0
+                    continue
+
+                wait = retry_after if retry_after is not None else min(64, 2 ** retries)
+                logger.warning("rate_limited host=%s wait=%.2fs", host, wait)
+            else:
+                wait = retry_after if retry_after is not None else (
+                    0.5 * (2 ** retries) + random.uniform(0, 0.5)
+                )
+
+            # Add +/-20%% jitter to the wait to avoid thundering herd.
+            wait *= random.uniform(0.8, 1.2)
+            if _wait_cb:
+                _wait_cb(wait)
+            retries += 1
+            await asyncio.sleep(wait)
+            if _wait_cb:
+                _wait_cb(0)
+
+    if key:
+        task = asyncio.create_task(_do_request())
+        _INFLIGHT[key] = task
+        try:
+            return await task
+        finally:
+            _INFLIGHT.pop(key, None)
+    else:
+        return await _do_request()
 
 
 async def get(url: str, **kwargs) -> httpx.Response:

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,189 @@
+import asyncio
+import time
+import json
+import httpx
+import pytest
+
+import asyncio
+import time
+import httpx
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from services import http_client
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    http_client.clear_cache()
+    yield
+    http_client.clear_cache()
+
+
+def install_mock(monkeypatch, handler):
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport)
+    monkeypatch.setattr(http_client, "get_client", lambda: client)
+    return client
+
+
+def test_retry_after_backoff(monkeypatch):
+    calls = []
+
+    async def handler(request):
+        calls.append(time.monotonic())
+        if len(calls) == 1:
+            return httpx.Response(429, headers={"Retry-After": "2"})
+        return httpx.Response(200, json={"ok": True})
+
+    install_mock(monkeypatch, handler)
+    start = time.monotonic()
+    data = asyncio.run(http_client.get_json("http://test/local"))
+    elapsed = time.monotonic() - start
+    assert data == {"ok": True}
+    # Wait should be approximately 2s with jitter +/-20%
+    assert 1.5 <= elapsed <= 2.5
+
+
+def test_jitter_present(monkeypatch):
+    # First three responses fail forcing retries without Retry-After
+    calls = []
+
+    async def handler(request):
+        calls.append(time.monotonic())
+        if len(calls) <= 3:
+            return httpx.Response(500)
+        return httpx.Response(200, json={"ok": True})
+
+    install_mock(monkeypatch, handler)
+    start = time.monotonic()
+    asyncio.run(http_client.get_json("http://test/jitter"))
+    # compute deltas between retries
+    waits = [t2 - t1 for t1, t2 in zip(calls, calls[1:4])]
+    # Default backoff would be 1,2,4 without jitter. Ensure we deviated by >0.1s
+    for expected, actual in zip([1, 2, 4], waits):
+        assert abs(actual - expected) > 0.1
+
+
+def test_rate_limiter(monkeypatch):
+    http_client.set_rate_limit("test", rate=1, capacity=2)
+    call_times = []
+
+    async def handler(request):
+        call_times.append(time.monotonic())
+        return httpx.Response(200, json={"ok": True})
+
+    install_mock(monkeypatch, handler)
+
+    async def run_all():
+        await asyncio.gather(*[http_client.get_json("http://test/rl") for _ in range(10)])
+
+    asyncio.run(run_all())
+    # Ensure no more than 2 requests occur within any one second window
+    for i in range(len(call_times)):
+        window = [t for t in call_times if 0 <= t - call_times[i] < 1]
+        assert len(window) <= 2
+
+
+def test_coalesce_and_cache(monkeypatch):
+    count = 0
+
+    async def handler(request):
+        nonlocal count
+        count += 1
+        return httpx.Response(200, json={"ok": True})
+
+    install_mock(monkeypatch, handler)
+
+    async def do_request():
+        return await http_client.get_json("http://test/cache")
+
+    async def run_all():
+        await asyncio.gather(*[do_request() for _ in range(5)])
+
+    # concurrent calls coalesce
+    asyncio.run(run_all())
+    assert count == 1
+    # second round hits cache
+    asyncio.run(do_request())
+    assert count == 1
+
+
+def test_fetch_prices_batching(monkeypatch):
+    from services import data_fetcher
+
+    tickers = [f"T{i}" for i in range(10)]
+    count = 0
+
+    async def handler(request):
+        nonlocal count
+        count += 1
+        url = httpx.URL(str(request.url))
+        symbols = url.params.get("symbols", "").split(",")
+        res = {
+            "spark": {
+                "result": [
+                    {
+                        "symbol": s,
+                        "response": [
+                            {
+                                "timestamp": [],
+                                "indicators": {"quote": [{}], "adjclose": [{}]},
+                            }
+                        ],
+                    }
+                    for s in symbols if s
+                ]
+            }
+        }
+        return httpx.Response(200, json=res)
+
+    install_mock(monkeypatch, handler)
+    monkeypatch.setenv("YF_BATCH_SIZE", "3")
+    data_fetcher.YF_BATCH_SIZE = 3
+    data_fetcher.fetch_prices(tickers, "1d", 1.0)
+    assert count == 4  # ceil(10/3)
+
+
+def test_progress_polling_does_not_hit_yahoo(monkeypatch):
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    import routes
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    # Stub Yahoo requests via http_client.get_json
+    calls = 0
+
+    async def fake_get_json(url, **kwargs):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.05)
+        return {"spark": {"result": []}}
+
+    monkeypatch.setattr(http_client, "get_json", fake_get_json)
+
+    # Replace _perform_scan to issue a single Yahoo request and then return.
+    def fake_perform_scan(tickers, params, sort_key, progress_cb=None):
+        asyncio.run(http_client.get_json("http://test/once"))
+        return [], 0
+
+    monkeypatch.setattr(routes, "_perform_scan", fake_perform_scan)
+    monkeypatch.setattr(routes, "SP100", ["AAA"])  # small universe
+
+    app = FastAPI()
+    app.include_router(routes.router)
+    client = TestClient(app)
+
+    res = client.post("/scanner/run", data={"scan_type": "sp100"})
+    task_id = res.json()["task_id"]
+    # Poll progress a few times while scan is running
+    for _ in range(3):
+        client.get(f"/scanner/progress/{task_id}")
+        time.sleep(0.02)
+
+    # Wait for task to finish
+    time.sleep(0.2)
+    assert calls == 1


### PR DESCRIPTION
## Summary
- add token-bucket limiter, exponential backoff with jitter, coalescing and short TTL cache for Yahoo calls
- expose rate-limit waits to progress API and adjust scanner batching
- add regression tests for backoff, jitter, caching, batching, coalescing and progress polling

## Testing
- `pytest tests/test_rate_limiter.py::test_retry_after_backoff -q`
- `pytest tests/test_rate_limiter.py::test_jitter_present -q`
- `pytest tests/test_rate_limiter.py::test_rate_limiter -q`
- `pytest tests/test_rate_limiter.py::test_coalesce_and_cache -q`
- `pytest tests/test_rate_limiter.py::test_fetch_prices_batching -q`
- `pytest tests/test_rate_limiter.py::test_progress_polling_does_not_hit_yahoo -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0ac100c9083299fe42c9e6f4a8bfa