### PR TITLE
Handle missing price data gracefully in scanner

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -23,7 +23,6 @@ from indices import SP100, TOP150, TOP250
 from db import DB_PATH, get_db, get_settings
 from scanner import compute_scan_for_ticker, preload_prices
 from services.market_data import get_prices, window_from_lookback
-from services.price_utils import DataUnavailableError
 from utils import now_et, TZ
 import pandas as pd
 
@@ -192,11 +191,10 @@ def _perform_scan(
         ticker = future_to_ticker[fut]
         try:
             r = fut.result()
-            if r:
+            if r is None:
+                skipped_missing_data += 1
+            elif r:
                 rows.append(r)
-        except DataUnavailableError:
-            skipped_missing_data += 1
-            logger.info("skip=%s reason=no_close_or_empty", ticker)
         except Exception as e:
             logger.error("scan failed for %s: %s", ticker, e)
         done += 1

--- a/tests/test_skip_missing_data.py
+++ b/tests/test_skip_missing_data.py
@@ -1,0 +1,42 @@
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import routes
+import scanner
+
+
+def test_perform_scan_counts_skipped(monkeypatch):
+    tickers = ["AAA", "BBB"]
+
+    def fake_scan(ticker, params):
+        if ticker == "BBB":
+            return None
+        return {"ticker": ticker}
+
+    monkeypatch.setattr(routes, "compute_scan_for_ticker", fake_scan)
+    monkeypatch.setattr(routes, "preload_prices", lambda *a, **k: None)
+
+    rows, skipped = routes._perform_scan(tickers, {}, "")
+    assert rows == [{"ticker": "AAA"}]
+    assert skipped == 1
+
+
+def test_compute_scan_skips_when_no_data(monkeypatch, caplog):
+    def fake_fetch(symbols, interval, lookback, provider=None):
+        return {symbols[0]: pd.DataFrame()}
+
+    monkeypatch.setattr(scanner, "fetch_prices", fake_fetch)
+    monkeypatch.setattr(scanner, "_PRICE_DATA", {})
+
+    params = {"interval": "1d", "lookback_years": 1.0}
+
+    with caplog.at_level(logging.INFO):
+        res = scanner.compute_scan_for_ticker("XYZ", params)
+
+    assert res is None
+    assert any("skip_no_data symbol=XYZ" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- Add data coverage checks with gap-fill fetch and skip logging
- Return `None` for tickers missing price data and count skips in scan loop
- Test scanner behaviour when price data is absent

## Testing
- `pytest -q`
- `pytest -q tests/test_skip_missing_data.py`
- ⚠️ `pre-commit run --files routes/__init__.py scanner.py tests/test_skip_missing_data.py` *(command failed: `bash: command not found: pre-commit`)*

------
https://chatgpt.com/codex/tasks/task_e_68c1af1eef248329990449db094a8a75