### PR TITLE
Refactor Polygon backfill to reuse event loop

### DIFF
--- a/services/http_client.py
+++ b/services/http_client.py
@@ -243,3 +243,11 @@ async def get(url: str, **kwargs) -> httpx.Response:
 async def get_json(url: str, **kwargs):
     resp = await get(url, **kwargs)
     return resp.json()
+
+
+async def aclose() -> None:
+    """Close the underlying AsyncClient and reset global state."""
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None

--- a/tests/test_backfill_multi_symbol.py
+++ b/tests/test_backfill_multi_symbol.py
@@ -1,0 +1,55 @@
+import datetime as dt
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import scripts.backfill_polygon as backfill
+from services import http_client, polygon_client
+
+
+def test_backfill_two_symbols(monkeypatch, caplog):
+    monkeypatch.setenv("POLYGON_API_KEY", "test")
+
+    df = pd.DataFrame(
+        {
+            "Open": [1],
+            "High": [1],
+            "Low": [1],
+            "Close": [1],
+            "Volume": [1],
+        },
+        index=pd.date_range("2024-01-01", periods=1, freq="15T", tz="UTC"),
+    )
+
+    async def fake_fetch(symbols, interval, start, end):
+        sym = symbols[0]
+        logger = logging.getLogger("services.polygon_client")
+        logger.info("polygon_fetch symbol=%s pages=1 rows=1 duration=0.00", sym)
+        return {sym: df}
+
+    monkeypatch.setattr(polygon_client, "fetch_polygon_prices_async", fake_fetch)
+
+    saved = {}
+
+    def fake_upsert(sym, data):
+        saved.setdefault(sym, 0)
+        saved[sym] += len(data)
+        return len(data)
+
+    monkeypatch.setattr(backfill, "upsert_bars", fake_upsert)
+
+    caplog.set_level(logging.INFO)
+    start = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+    end = start + dt.timedelta(days=1)
+    client = http_client.get_client()
+    backfill.backfill(["SPY", "QQQ"], start=start, end=end, use_checkpoint=False)
+    assert client.is_closed
+    assert saved["SPY"] > 0
+    assert saved["QQQ"] > 0
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any("backfill symbol=SPY returned=1 saved=1" in m for m in messages)
+    assert any("backfill symbol=QQQ returned=1 saved=1" in m for m in messages)

--- a/tests/test_backfill_resume.py
+++ b/tests/test_backfill_resume.py
@@ -1,12 +1,13 @@
 import json
-import pandas as pd
-from pathlib import Path
 import sys
+from pathlib import Path
+
+import pandas as pd
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import scripts.backfill_polygon as backfill
-from services import polygon_client
+from services import http_client, polygon_client
 
 
 def test_backfill_resume(monkeypatch, tmp_path):
@@ -19,16 +20,21 @@ def test_backfill_resume(monkeypatch, tmp_path):
     monkeypatch.setattr(backfill, "CHECKPOINT", chk)
 
     # stub polygon fetch
-    def fake_fetch(symbols, interval, start, end):
+    async def fake_fetch(symbols, interval, start, end):
         return {symbols[0]: pd.DataFrame()}
-    monkeypatch.setattr(polygon_client, "fetch_polygon_prices", fake_fetch)
+
+    monkeypatch.setattr(polygon_client, "fetch_polygon_prices_async", fake_fetch)
 
     called = []
+
     def fake_upsert(sym, df):
         called.append(sym)
         return 0
+
     monkeypatch.setattr(backfill, "upsert_bars", fake_upsert)
     monkeypatch.setattr(backfill.time, "sleep", lambda x: None)
 
+    client = http_client.get_client()
     backfill.backfill(symbols)
+    assert client.is_closed
     assert called == ["BBB", "CCC"]


### PR DESCRIPTION
## Summary
- avoid repeatedly creating/closing event loops during Polygon backfill
- add async HTTP client shutdown
- exercise backfill with multiple symbols

## Testing
- `pre-commit run --files services/http_client.py services/polygon_client.py scripts/backfill_polygon.py tests/test_backfill_test_mode.py tests/test_backfill_resume.py tests/test_backfill_multi_symbol.py` *(fails: Source file found twice, missing pandas stubs)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2447376ac83299658fde03be8536d