### PR TITLE
Add mypy override for pandas_market_calendars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,7 @@ strict = false
 [[tool.mypy.overrides]]
 module = "alembic_stub.*"
 ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "pandas_market_calendars.*"
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- ignore missing imports for pandas_market_calendars modules in mypy config

## Testing
- `pre-commit run --files app.py utils.py tests/test_utils.py` *(fails: mypy found 26 errors in 11 files)*

------
https://chatgpt.com/codex/tasks/task_e_68c45597cab4832991a99b43b18a3b7a