### PR TITLE
Limit coverage calculations to market hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ suite with:
 pytest
 ```
 
+## Scanning
+
+During a scan, the application verifies that price data covers at least 95% of the
+expected bars in the lookback window. For intraday intervals, expected bars are
+derived from actual market sessions: only minutes when the market is open are
+counted. Weekends and holidays therefore no longer inflate the coverage
+requirement.
+
 ## Environment
 
 Copy `.env.example` to `.env` and adjust:

--- a/app.py
+++ b/app.py
@@ -17,7 +17,6 @@ try:  # pragma: no cover - optional speed-up
 except Exception:
     pass
 
-from config import settings
 from db import init_db
 from routes import router
 from scanner import compute_scan_for_ticker
@@ -50,7 +49,7 @@ def create_app() -> FastAPI:
     os.makedirs("static", exist_ok=True)
 
     logger.info("Initializing database")
-    if settings.run_migrations:
+    if os.getenv("RUN_MIGRATIONS", "true").lower() not in {"0", "false", ""}:
         logger.info("Running database migrations")
         init_db()
     else:

--- a/db.py
+++ b/db.py
@@ -1,12 +1,11 @@
 import logging
+import os
 import sqlite3
 from pathlib import Path
 from typing import Optional
 
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
-
-from config import settings
 
 try:  # pragma: no cover - prefer real Alembic if available
     from alembic import command as alembic_command
@@ -27,7 +26,7 @@ DB_PATH = str(Path(__file__).resolve().with_name("patternfinder.db"))
 # production deployments.  Using SQLAlchemy here keeps the code database
 # agnostic between SQLite (tests) and Postgres (prod).
 
-_ENV_DATABASE_URL = settings.database_url
+_ENV_DATABASE_URL = os.getenv("DATABASE_URL", "")
 
 _ENGINE: Optional[Engine] = None
 


### PR DESCRIPTION
## Summary
- derive expected bar counts from exchange sessions
- require intraday coverage only during market hours
- document intraday coverage rules and add regression test
- expose `healthz`/`metrics` helpers and make DB/app respect env overrides

## Testing
- `PYTHONPATH=. pytest tests/test_skip_missing_data.py::test_ensure_coverage_intraday -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c46a5970a4832997707cdf8a922347