### PR TITLE
Fix pytest import path issues for db module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,11 @@
 import os
+import sys
+from pathlib import Path
+
+# Ensure the project root is on the import path when running ``pytest`` directly.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from db import DB_PATH, run_migrations
 


### PR DESCRIPTION
## Summary
- ensure project root is added to `sys.path` so `pytest` can import `db`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4db00ca2c8329add43df630be4355