### PR TITLE
Add guardrails, versioning, and weekly digest for forward tests

### DIFF
--- a/cohorts.py
+++ b/cohorts.py
@@ -1,0 +1,95 @@
+"""Utilities for aggregating forward test results into cohorts.
+
+This module provides a helper used by forward-test monitoring features.
+The ``cohort_rollup`` function groups rows by week and strategy and computes
+rolling metrics such as average ROI, hit rate and drawdown.  Each cohort is
+assigned a colour-coded status based on configurable thresholds so callers can
+quickly highlight deteriorating performance.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Dict, List
+
+import pandas as pd
+
+
+@dataclass
+class CohortRow:
+    """Internal representation of a rollup row."""
+
+    week: pd.Timestamp
+    rule: str
+    count: int
+    hit_pct: float | None
+    roi: float | None
+    dd: float | None
+    status: str
+
+
+def cohort_rollup(
+    rows: Iterable[Dict],
+    *,
+    rolling_n: int = 20,
+    hit_red: float = 55.0,
+    dd_red: float = 60.0,
+) -> List[Dict]:
+    """Aggregate forward test results by week and strategy.
+
+    Rolling averages are computed for each strategy over ``rolling_n`` weeks.
+    Status colours are determined by comparing the rolling hit rate and
+    drawdown against the provided thresholds.  ``green`` indicates the cohort is
+    above both thresholds, ``red`` represents degradation, and ``yellow`` is a
+    warning band within ten percentage points of the thresholds.
+    """
+
+    df = pd.DataFrame(list(rows))
+    if df.empty:
+        return []
+
+    df["created_at"] = pd.to_datetime(df["created_at"])
+    df["week"] = df["created_at"].dt.to_period("W").dt.start_time
+    grouped = (
+        df.groupby(["week", "rule"])[["hit_forward", "roi_forward", "dd_forward"]]
+        .mean()
+        .reset_index()
+        .sort_values(["rule", "week"])
+    )
+
+    grouped["hit_pct"] = grouped.groupby("rule")[["hit_forward"]].transform(
+        lambda s: s.rolling(rolling_n, min_periods=1).mean()
+    )
+    grouped["roi"] = grouped.groupby("rule")[["roi_forward"]].transform(
+        lambda s: s.rolling(rolling_n, min_periods=1).mean()
+    )
+    grouped["dd"] = grouped.groupby("rule")[["dd_forward"]].transform(
+        lambda s: s.rolling(rolling_n, min_periods=1).mean()
+    )
+
+    out: List[Dict] = []
+    for _, row in grouped.iterrows():
+        hit = float(row.get("hit_pct")) if pd.notna(row.get("hit_pct")) else None
+        roi = float(row.get("roi")) if pd.notna(row.get("roi")) else None
+        dd = float(row.get("dd")) if pd.notna(row.get("dd")) else None
+        status = "gray"
+        if hit is not None and dd is not None:
+            if hit < hit_red or dd > dd_red:
+                status = "red"
+            elif hit < hit_red + 10 or dd > dd_red - 10:
+                status = "yellow"
+            else:
+                status = "green"
+        out.append(
+            CohortRow(
+                week=pd.Timestamp(row["week"]),
+                rule=str(row["rule"]),
+                count=0,
+                hit_pct=hit,
+                roi=roi,
+                dd=dd,
+                status=status,
+            ).__dict__,
+        )
+    return out

--- a/db.py
+++ b/db.py
@@ -131,6 +131,7 @@ SCHEMA = [
         direction TEXT NOT NULL,
         interval TEXT NOT NULL,
         rule TEXT,
+        version INTEGER NOT NULL DEFAULT 1,
         entry_price REAL NOT NULL,
         target_pct REAL NOT NULL,
         stop_pct REAL NOT NULL,
@@ -161,6 +162,15 @@ SCHEMA = [
     );
     """,
     "CREATE INDEX IF NOT EXISTS idx_forward_tests_fav ON forward_tests(fav_id);",
+    # Guardrail skip log
+    """
+    CREATE TABLE IF NOT EXISTS guardrail_skips (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        ticker TEXT NOT NULL,
+        reason TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+    """,
     # Runs (archive)
     """
     CREATE TABLE IF NOT EXISTS runs (

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -1,0 +1,38 @@
+import pandas as pd
+
+from cohorts import cohort_rollup
+
+
+def test_cohort_rollup_status_and_rolling():
+    rows = [
+        {
+            "created_at": "2024-01-01T12:00:00",
+            "rule": "r1",
+            "hit_forward": 100.0,
+            "roi_forward": 2.0,
+            "dd_forward": 10.0,
+        },
+        {
+            "created_at": "2024-01-03T09:30:00",
+            "rule": "r1",
+            "hit_forward": 100.0,
+            "roi_forward": 2.0,
+            "dd_forward": 10.0,
+        },
+        {
+            "created_at": "2024-01-10T09:30:00",
+            "rule": "r1",
+            "hit_forward": 0.0,
+            "roi_forward": -2.0,
+            "dd_forward": 70.0,
+        },
+    ]
+    result = cohort_rollup(rows)
+    assert len(result) == 2
+    first, second = result
+    assert pd.Timestamp(first["week"]) == pd.Timestamp("2024-01-01")
+    assert pd.Timestamp(second["week"]) == pd.Timestamp("2024-01-08")
+    assert first["hit_pct"] == 100.0
+    assert second["hit_pct"] == 50.0
+    assert first["status"] == "green"
+    assert second["status"] == "red"

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1,0 +1,37 @@
+import sqlite3
+
+import pandas as pd
+
+import db
+from routes import compile_weekly_digest
+
+
+def test_compile_weekly_digest(tmp_path):
+    db.DB_PATH = str(tmp_path / "test.db")
+    db.init_db()
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO favorites(id, ticker, direction, interval, rule, target_pct, stop_pct, window_value, window_unit) "
+        "VALUES (1,'AAA','UP','15m','r1',1.0,0.5,1,'Hours')"
+    )
+    conn.commit()
+
+    now = pd.Timestamp("2024-01-12 21:00:00", tz="America/New_York")
+    start_iso = pd.Timestamp("2024-01-08", tz="America/New_York").isoformat()
+    cur.execute(
+        "INSERT INTO forward_tests(fav_id,ticker,direction,interval,rule,version,entry_price,target_pct,stop_pct,window_minutes,status,roi_forward,hit_forward,dd_forward,created_at,updated_at) "
+        "VALUES (1,'AAA','UP','15m','r1',1,100,1,0.5,60,'target',5,60,10,?,?)",
+        (start_iso, start_iso),
+    )
+    cur.execute(
+        "INSERT INTO guardrail_skips(ticker, reason, created_at) VALUES ('BBB','earnings',?)",
+        (start_iso,),
+    )
+    conn.commit()
+
+    subject, body = compile_weekly_digest(cur, ts=now)
+    assert "[Forward Digest] Week of 2024-01-08" in subject
+    assert "1 New" in subject
+    assert "earnings: 1" in body
+    conn.close()

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,61 @@
+import sqlite3
+
+import pandas as pd
+
+import db
+from routes import _create_forward_test, check_guardrails
+
+
+def test_guardrail_skip(monkeypatch, tmp_path):
+    db.DB_PATH = str(tmp_path / "test.db")
+    db.init_db()
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    # Insert a favorite required by foreign key
+    cur.execute(
+        "INSERT INTO favorites(id, ticker, direction, interval, "
+        "rule, target_pct, stop_pct, window_value, window_unit) "
+        "VALUES (1, 'AAA','UP','15m','r1',1.0,0.5,1,'Hours')"
+    )
+    conn.commit()
+
+    ts = pd.Timestamp("2024-01-01", tz="UTC")
+    df = pd.DataFrame({"Close": [100.0], "High": [100.0], "Low": [100.0]}, index=[ts])
+    monkeypatch.setattr("routes.get_prices", lambda *a, **k: {"AAA": df})
+    monkeypatch.setattr("routes.check_guardrails", lambda ticker: (False, ["earnings"]))
+    fav = {
+        "id": 1,
+        "ticker": "AAA",
+        "direction": "UP",
+        "interval": "15m",
+        "rule": "r1",
+        "target_pct": 1.0,
+        "stop_pct": 0.5,
+        "window_value": 1,
+        "window_unit": "Hours",
+    }
+    _create_forward_test(cur, fav)
+    cur.execute("SELECT count(*) FROM forward_tests")
+    assert cur.fetchone()[0] == 0
+    cur.execute("SELECT reason FROM guardrail_skips")
+    assert cur.fetchone()[0] == "earnings"
+    conn.close()
+
+
+def test_check_guardrails(monkeypatch):
+    today = pd.Timestamp("2024-01-01", tz="America/New_York")
+    monkeypatch.setattr("routes.now_et", lambda: today)
+    allowed, flags = check_guardrails(
+        "AAA",
+        get_earnings=lambda t: today + pd.Timedelta(days=3),
+        get_adv=lambda t: 1_000_000,
+    )
+    assert not allowed and "earnings" in flags
+
+    allowed, flags = check_guardrails(
+        "AAA",
+        get_earnings=lambda t: None,
+        get_adv=lambda t: 100,
+        adv_threshold=1_000,
+    )
+    assert not allowed and "low_liquidity" in flags

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,46 @@
+import sqlite3
+
+import pandas as pd
+
+import db
+import routes
+
+
+def test_forward_version_increment(monkeypatch, tmp_path):
+    db.DB_PATH = str(tmp_path / "test.db")
+    db.init_db()
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO favorites(id, ticker, direction, interval, rule, target_pct, stop_pct, window_value, window_unit) "
+        "VALUES (1,'AAA','UP','15m','r1',1.0,0.5,1,'Hours')"
+    )
+    conn.commit()
+
+    ts = pd.Timestamp("2024-01-01", tz="UTC")
+    df = pd.DataFrame({"Close": [100.0], "High": [100.0], "Low": [100.0]}, index=[ts])
+    monkeypatch.setattr(routes, "get_prices", lambda *a, **k: {"AAA": df})
+    monkeypatch.setattr(routes, "check_guardrails", lambda t: (True, []))
+
+    fav = {
+        "id": 1,
+        "ticker": "AAA",
+        "direction": "UP",
+        "interval": "15m",
+        "rule": "r1",
+        "target_pct": 1.0,
+        "stop_pct": 0.5,
+        "window_value": 1,
+        "window_unit": "Hours",
+    }
+    routes._create_forward_test(cur, fav)
+
+    fav["target_pct"] = 2.0
+    routes._create_forward_test(cur, fav)
+
+    cur.execute("SELECT version, status FROM forward_tests ORDER BY id")
+    rows = cur.fetchall()
+    assert rows[0][0] == 1
+    assert rows[0][1] == "closed"
+    assert rows[1][0] == 2
+    conn.close()


### PR DESCRIPTION
## Summary
- compute rolling cohort metrics with status colors
- add earnings and liquidity guardrails with skip logging and forward-test versioning
- generate weekly digest email summarizing new/resolved tests and guardrail counts

## Testing
- `pytest`
- `pre-commit run --files cohorts.py routes/__init__.py db.py tests/test_cohorts.py tests/test_guardrails.py tests/test_versioning.py tests/test_digest.py` *(fails: missing pandas stubs and widespread mypy type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ea2a9f248329a00b4f88ad071470