### PR TITLE
add sms/mms alert templates and carrier mapping

### DIFF
--- a/services/notifications.py
+++ b/services/notifications.py
@@ -1,0 +1,87 @@
+"""Utilities for formatting Favorite Alert messages for email-to-SMS gateways.
+
+This module defines carrier domain mappings and helpers for generating SMS
+and MMS message bodies according to the project specification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Mapping of supported carriers to their email gateway domains.  The ``sms``
+# domain is used for short 160 character messages while ``mms`` allows longer
+# multi-line messages.
+CARRIER_DOMAINS: dict[str, dict[str, str]] = {
+    "att": {"sms": "txt.att.net", "mms": "mms.att.net"},
+    # Mint Mobile uses the T‑Mobile gateway
+    "mint": {"sms": "tmomail.net", "mms": "tmomail.net"},
+    "tmobile": {"sms": "tmomail.net", "mms": "tmomail.net"},
+    "verizon": {"sms": "vtext.com", "mms": "vzwpix.com"},
+}
+
+def build_recipient(
+    number: str,
+    carrier: str,
+    *,
+    mms: bool = False,
+    custom_domain: str | None = None,
+) -> str:
+    """Return an email address for the given phone ``number`` and ``carrier``.
+
+    ``carrier`` may be one of the keys in :data:`CARRIER_DOMAINS` or ``"custom"``
+    to supply an arbitrary ``custom_domain``.  ``mms`` selects the MMS gateway
+    when available.
+    """
+
+    number = number.replace("-", "").replace(" ", "")
+    if carrier == "custom":
+        if not custom_domain:
+            raise ValueError("custom_domain required for custom carrier")
+        domain = custom_domain
+    else:
+        info = CARRIER_DOMAINS.get(carrier.lower())
+        if not info:
+            raise KeyError(f"unsupported carrier: {carrier}")
+        domain = info["mms" if mms else "sms"]
+    return f"{number}@{domain}"
+
+
+@dataclass
+class AlertDetails:
+    ticker: str
+    direction: str  # "UP" or "DOWN"
+    hit: float
+    target: float
+    stop: float
+    expiry: str  # expected MM/DD string
+    strike: str  # e.g. "190C" or "325P"
+    hit_pct: int
+    support: int | None = None
+
+
+def format_sms(details: AlertDetails) -> str:
+    """Return a compact single line SMS alert (<=160 chars)."""
+
+    direction = details.direction.upper()
+    msg = (
+        f"{details.ticker} {direction} hit {details.hit:.2f} | "
+        f"T:{details.target:.1f} S:{details.stop:.1f} | "
+        f"Exp {details.expiry} {details.strike} | Hit%:{details.hit_pct}"
+    )
+    if len(msg) > 160:
+        raise ValueError("SMS alert exceeds 160 characters")
+    return msg
+
+
+def format_mms(details: AlertDetails) -> tuple[str, str]:
+    """Return (subject, body) for an MMS alert."""
+
+    subject = f"Pattern Alert: {details.ticker} {details.direction.upper()}"
+    body_lines = [
+        f"{details.ticker} {details.direction.upper()} hit {details.hit:.2f}",
+        f"Target {details.target:.1f} | Stop {details.stop:.1f}",
+        f"Expiry {details.expiry} {details.strike}",
+        f"Hit% {details.hit_pct}"
+        + (f" | Support {details.support}" if details.support is not None else ""),
+    ]
+    return subject, "\n".join(body_lines)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,114 @@
+import pytest
+
+from services.notifications import AlertDetails, build_recipient, format_mms, format_sms
+
+
+def test_build_recipient_supported_carriers_sms_and_mms():
+    number = "5551234567"
+    # Mint Mobile (uses tmomail.net for both SMS and MMS)
+    assert build_recipient(number, "mint") == f"{number}@tmomail.net"
+    assert build_recipient(number, "mint", mms=True) == f"{number}@tmomail.net"
+    # AT&T (separate domains for SMS and MMS)
+    assert build_recipient(number, "att") == f"{number}@txt.att.net"
+    assert build_recipient(number, "att", mms=True) == f"{number}@mms.att.net"
+    # Verizon fallback
+    assert build_recipient(number, "verizon") == f"{number}@vtext.com"
+    assert build_recipient(number, "verizon", mms=True) == f"{number}@vzwpix.com"
+
+
+def test_build_recipient_custom_domain():
+    assert (
+        build_recipient("5551234567", "custom", custom_domain="example.com")
+        == "5551234567@example.com"
+    )
+    with pytest.raises(ValueError):
+        build_recipient("555", "custom")
+
+
+def test_format_sms_call_and_put():
+    call = AlertDetails(
+        ticker="AAPL",
+        direction="UP",
+        hit=188.20,
+        target=191.5,
+        stop=186.8,
+        expiry="09/19",
+        strike="190C",
+        hit_pct=87,
+    )
+    msg = format_sms(call)
+    assert msg == "AAPL UP hit 188.20 | T:191.5 S:186.8 | Exp 09/19 190C | Hit%:87"
+    assert len(msg) <= 160
+
+    put = AlertDetails(
+        ticker="MSFT",
+        direction="DOWN",
+        hit=328.40,
+        target=320.0,
+        stop=332.5,
+        expiry="09/19",
+        strike="325P",
+        hit_pct=72,
+    )
+    msg = format_sms(put)
+    assert msg == "MSFT DOWN hit 328.40 | T:320.0 S:332.5 | Exp 09/19 325P | Hit%:72"
+    assert len(msg) <= 160
+
+
+def test_format_mms_with_support():
+    details = AlertDetails(
+        ticker="AAPL",
+        direction="UP",
+        hit=188.20,
+        target=191.5,
+        stop=186.8,
+        expiry="09/19",
+        strike="190C",
+        hit_pct=87,
+        support=12,
+    )
+    subject, body = format_mms(details)
+    assert subject == "Pattern Alert: AAPL UP"
+    assert body == (
+        "AAPL UP hit 188.20\n"
+        "Target 191.5 | Stop 186.8\n"
+        "Expiry 09/19 190C\n"
+        "Hit% 87 | Support 12"
+    )
+
+
+def test_format_mms_put_without_support():
+    details = AlertDetails(
+        ticker="MSFT",
+        direction="DOWN",
+        hit=328.40,
+        target=320.0,
+        stop=332.5,
+        expiry="09/19",
+        strike="325P",
+        hit_pct=72,
+    )
+    subject, body = format_mms(details)
+    assert subject == "Pattern Alert: MSFT DOWN"
+    assert body == (
+        "MSFT DOWN hit 328.40\n"
+        "Target 320.0 | Stop 332.5\n"
+        "Expiry 09/19 325P\n"
+        "Hit% 72"
+    )
+
+
+def test_format_sms_raises_when_over_limit():
+    details = AlertDetails(
+        ticker="TOOLONG",
+        direction="UP",
+        hit=1.0,
+        target=2.0,
+        stop=0.5,
+        expiry="09/19",
+        strike="1C",
+        hit_pct=100,
+    )
+    details.ticker = "A" * 200  # make the message exceed 160 chars
+    with pytest.raises(ValueError):
+        format_sms(details)


### PR DESCRIPTION
## Summary
- add notification helpers to format SMS and MMS favorite alerts
- support Mint Mobile, AT&T, T-Mobile and Verizon carrier domains
- test formatting to ensure SMS length stays under 160 chars
- verify carrier gateway addresses for Mint Mobile, AT&T and Verizon

## Testing
- `ruff check services/notifications.py tests/test_notifications.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4f0768fa08329a69f8a757a28772c