### PR TITLE
Split notification recipients

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -14,7 +14,11 @@
           <input name="smtp_pass" type="password" value="{{ st['smtp_pass'] or '' }}" />
         </div>
         <div>
-          <label>Recipients (comma-separated)</label>
+          <label>Scanner Results Recipients (comma-separated)</label>
+          <input name="scanner_recipients" value="{{ st['scanner_recipients'] or '' }}" />
+        </div>
+        <div>
+          <label>Favorites Alert Recipients (comma-separated)</label>
           <input name="recipients" value="{{ st['recipients'] or '' }}" />
         </div>
         <div>

--- a/tests/test_recipient_lists.py
+++ b/tests/test_recipient_lists.py
@@ -1,0 +1,53 @@
+import smtplib
+
+from routes import _send_email
+
+
+def _dummy_smtp(sent):
+    class DummySMTP:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def login(self, user, pwd):
+            pass
+
+        def send_message(self, msg):
+            sent.append(msg)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    return DummySMTP
+
+
+def test_scanner_recipients_ignore_sms(monkeypatch):
+    sent = []
+    dummy = _dummy_smtp(sent)
+    monkeypatch.setattr(smtplib, "SMTP_SSL", dummy)
+    monkeypatch.setattr(smtplib, "SMTP", dummy)
+    st = {
+        "smtp_user": "u@example.com",
+        "smtp_pass": "pw",
+        "scanner_recipients": "user@example.com, 5551234567@txt.att.net",
+    }
+    _send_email(st, "sub", "body", list_field="scanner_recipients", allow_sms=False)
+    assert len(sent) == 1
+    assert sent[0]["To"] == "user@example.com"
+
+
+def test_favorites_recipients_allow_sms(monkeypatch):
+    sent = []
+    dummy = _dummy_smtp(sent)
+    monkeypatch.setattr(smtplib, "SMTP_SSL", dummy)
+    monkeypatch.setattr(smtplib, "SMTP", dummy)
+    st = {
+        "smtp_user": "u@example.com",
+        "smtp_pass": "pw",
+        "recipients": "user@example.com, 5551234567@txt.att.net",
+    }
+    _send_email(st, "sub", "body")
+    assert len(sent) == 1
+    assert sent[0]["To"] == "user@example.com, 5551234567@txt.att.net"


### PR DESCRIPTION
## Summary
- Add scanner-specific recipient list to settings and database
- Filter SMS/MMS gateways from scanner result emails
- Expose separate scanner and favorites recipient fields in settings page
- Ensure logging identifies which list was used and add tests for recipient filtering

## Testing
- `pytest` *(fails: tests/test_polygon_chunking.py::test_week_chunking)*

------
https://chatgpt.com/codex/tasks/task_e_68c50b96095c832992dbfca84715a191