### PR TITLE
Clamp backfills to last market close and add retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Copy `.env.example` to `.env` and adjust:
 - `POLY_RPS` / `POLY_BURST` – Polygon rate limit settings
 - `DB_CACHE_TTL` – in-process DB cache TTL
 - `POLYGON_INCLUDE_PREPOST` – include pre/post market bars when true
+- `CLAMP_MARKET_CLOSED` – clamp backfills to last market close (default true)
+- `BACKFILL_CHUNK_DAYS` – days per backfill slice (default 1)
+- `FETCH_RETRY_MAX` – max retry attempts for Polygon fetches (default 4)
+- `FETCH_RETRY_BASE_MS` – base backoff in milliseconds (default 300)
+- `FETCH_RETRY_CAP_MS` – maximum backoff in milliseconds (default 5000)
 
 ## Backfill and ETL
 
@@ -75,3 +80,11 @@ Run the nightly ETL to heal recent gaps or fetch missing bars manually using
 ## Rotate API Key
 
 Update `POLYGON_API_KEY` in your environment or `.env` file and restart the process.
+
+## Changelog
+
+- Add market-closed clamp, chunked backfill and bounded Polygon retries.
+
+## Deployment Notes
+
+Set any new environment variables as needed and restart the `petra` service.

--- a/config.py
+++ b/config.py
@@ -13,6 +13,11 @@ class Settings:
     http_max_concurrency: int = int(os.getenv("HTTP_MAX_CONCURRENCY", "10"))
     job_timeout: int = int(os.getenv("JOB_TIMEOUT", "30"))
     metrics_enabled: bool = _bool("METRICS_ENABLED", "false")
+    clamp_market_closed: bool = _bool("CLAMP_MARKET_CLOSED", "true")
+    backfill_chunk_days: int = int(os.getenv("BACKFILL_CHUNK_DAYS", "1"))
+    fetch_retry_max: int = int(os.getenv("FETCH_RETRY_MAX", "4"))
+    fetch_retry_base_ms: int = int(os.getenv("FETCH_RETRY_BASE_MS", "300"))
+    fetch_retry_cap_ms: int = int(os.getenv("FETCH_RETRY_CAP_MS", "5000"))
 
 
 settings = Settings()

--- a/tests/test_clamp.py
+++ b/tests/test_clamp.py
@@ -1,0 +1,65 @@
+import datetime as dt
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import utils
+from utils import TZ, clamp_market_closed
+
+
+@pytest.fixture(autouse=True)
+def no_calendar(monkeypatch):
+    monkeypatch.setattr(utils, "mcal", None)
+    monkeypatch.setattr(utils, "_XNYS", None)
+
+
+def test_clamp_noop_during_market():
+    start = dt.datetime(2023, 1, 3, 14, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2023, 1, 3, 15, tzinfo=dt.timezone.utc)
+    new_end, clamped = clamp_market_closed(start, end)
+    assert new_end == end
+    assert clamped is False
+
+
+def test_clamp_after_hours():
+    start = dt.datetime(2023, 1, 3, 20, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2023, 1, 3, 22, tzinfo=dt.timezone.utc)
+    new_end, clamped = clamp_market_closed(start, end)
+    assert clamped is True
+    assert new_end == dt.datetime(2023, 1, 3, 21, tzinfo=dt.timezone.utc)
+
+
+def test_clamp_weekend():
+    start = dt.datetime(2023, 1, 6, 19, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2023, 1, 7, 16, tzinfo=dt.timezone.utc)
+    new_end, clamped = clamp_market_closed(start, end)
+    assert clamped is True
+    assert new_end == dt.datetime(2023, 1, 6, 21, tzinfo=dt.timezone.utc)
+
+
+def test_clamp_holiday(monkeypatch):
+    original = utils.market_is_open
+
+    def fake_market_is_open(ts=None):
+        ts = ts or dt.datetime.now(tz=TZ)
+        if ts.date() == dt.date(2023, 7, 4):
+            return False
+        return original(ts)
+
+    monkeypatch.setattr(utils, "market_is_open", fake_market_is_open)
+    start = dt.datetime(2023, 7, 3, 12, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2023, 7, 4, 16, tzinfo=dt.timezone.utc)
+    new_end, clamped = clamp_market_closed(start, end)
+    assert clamped is True
+    assert new_end == dt.datetime(2023, 7, 3, 20, tzinfo=dt.timezone.utc)
+
+
+def test_friday_close_to_monday_open():
+    start = dt.datetime(2023, 1, 6, 21, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2023, 1, 9, 13, tzinfo=dt.timezone.utc)
+    new_end, clamped = clamp_market_closed(start, end)
+    assert clamped is True
+    assert new_end == start

--- a/tests/test_polygon_retry.py
+++ b/tests/test_polygon_retry.py
@@ -1,0 +1,75 @@
+import asyncio
+import datetime as dt
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from services import polygon_client
+
+
+def test_retry_success(monkeypatch, caplog):
+    attempts = 0
+
+    async def fake_get_json(url, headers=None):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            resp = httpx.Response(500, request=httpx.Request("GET", url))
+            raise httpx.HTTPStatusError("boom", request=resp.request, response=resp)
+        return {"results": []}
+
+    async def fake_sleep(_):
+        return None
+
+    monkeypatch.setattr(
+        polygon_client, "http_client", SimpleNamespace(get_json=fake_get_json)
+    )
+    monkeypatch.setattr(polygon_client.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(
+        polygon_client,
+        "settings",
+        SimpleNamespace(fetch_retry_max=4, fetch_retry_base_ms=1, fetch_retry_cap_ms=2),
+    )
+
+    start = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2023, 1, 2, tzinfo=dt.timezone.utc)
+    with caplog.at_level("WARNING"):
+        asyncio.run(polygon_client._fetch_single("SPY", start, end))
+    assert attempts == 3
+    msgs = [r.message for r in caplog.records if "retry attempt" in r.message]
+    assert len(msgs) == 2
+    assert "status=500" in msgs[0]
+
+
+def test_retry_exhaust(monkeypatch):
+    attempts = 0
+
+    async def fake_get_json(url, headers=None):
+        nonlocal attempts
+        attempts += 1
+        resp = httpx.Response(500, request=httpx.Request("GET", url))
+        raise httpx.HTTPStatusError("boom", request=resp.request, response=resp)
+
+    async def fake_sleep(_):
+        return None
+
+    monkeypatch.setattr(
+        polygon_client, "http_client", SimpleNamespace(get_json=fake_get_json)
+    )
+    monkeypatch.setattr(polygon_client.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(
+        polygon_client,
+        "settings",
+        SimpleNamespace(fetch_retry_max=2, fetch_retry_base_ms=1, fetch_retry_cap_ms=2),
+    )
+
+    start = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2023, 1, 2, tzinfo=dt.timezone.utc)
+    with pytest.raises(httpx.HTTPStatusError):
+        asyncio.run(polygon_client._fetch_single("SPY", start, end))
+    assert attempts == 2


### PR DESCRIPTION
## Summary
- clamp gap-fill requests to the most recent market close and skip fully closed windows
- backfill missing ranges in configurable day-sized chunks
- add bounded retry with jitter for Polygon requests

## Testing
- `pre-commit run --files config.py utils.py scheduler.py services/polygon_client.py README.md tests/test_clamp.py tests/test_polygon_retry.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c714bb285483298a80f02816ffb8fc