### PR TITLE
Emit tracebacks for scheduler failures

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,11 @@
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    force=True,  # override any JSON handler that hides exc_info
+)
+
 from app import app
 
-__all__ = ['app']
+__all__ = ["app"]

--- a/scheduler.py
+++ b/scheduler.py
@@ -197,8 +197,8 @@ async def favorites_loop(
                         # TODO: email YES hits in a readable format
                         # TODO: archive favorites 15m scan results only if there are YES hits
                         set_last_run(boundary.isoformat(), db)
-        except Exception as e:
-            logger.error("scheduler error: %r", e)
+        except Exception:
+            logger.exception("scheduler error")
         elapsed = asyncio.get_event_loop().time() - start_time
         await asyncio.sleep(max(0, 60 - elapsed))
 
@@ -224,8 +224,8 @@ async def forward_tests_loop(
                     conn.row_factory = sqlite3.Row
                     db = conn.cursor()
                     _update_forward_tests(db)
-        except Exception as e:
-            logger.error("forward tests loop error: %r", e)
+        except Exception:
+            logger.exception("forward tests loop error")
         elapsed = asyncio.get_event_loop().time() - start_time
         await asyncio.sleep(max(0, 60 - elapsed))
 


### PR DESCRIPTION
## Summary
- log full tracebacks for scheduler and forward test loop errors
- configure logging to output tracebacks to journald

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c730a35af88329b7552e51bb3b2c59