### PR TITLE
Fix scheduler gap job failing due to calendar lookup

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,3 +18,10 @@ def test_market_is_closed_on_holiday():
     pytest.importorskip("pandas_market_calendars")
     ts = datetime.datetime(2023, 7, 4, 12, tzinfo=TZ)
     assert market_is_open(ts) is False
+
+
+def test_market_is_closed_on_future_date():
+    """Ensure future dates outside calendar range don't raise errors."""
+    pytest.importorskip("pandas_market_calendars")
+    ts = datetime.datetime(2035, 1, 1, 12, tzinfo=TZ)
+    assert market_is_open(ts) is False

--- a/utils.py
+++ b/utils.py
@@ -45,8 +45,11 @@ def market_is_open(ts: Optional[datetime] = None) -> bool:
         schedule = _XNYS.schedule(start_date=ts.date(), end_date=ts.date())
         if schedule.empty:
             return False
-        open_dt = schedule.at[ts.date(), "market_open"].to_pydatetime().astimezone(TZ)
-        close_dt = schedule.at[ts.date(), "market_close"].to_pydatetime().astimezone(TZ)
+        row = schedule.iloc[0]
+        if getattr(row, "name", None).date() != ts.date():
+            return False
+        open_dt = row["market_open"].to_pydatetime().astimezone(TZ)
+        close_dt = row["market_close"].to_pydatetime().astimezone(TZ)
         return open_dt <= ts <= close_dt
 
     # Fallback: assume regular hours and no holidays


### PR DESCRIPTION
## Summary
- prevent `market_is_open` from raising when `pandas_market_calendars` lacks a schedule entry for a date
- add regression test covering far-future dates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7383313148329b8df1747085eef98