### PR TITLE
Fix async gap fetcher to respect window and handle empties

### DIFF
--- a/tests/test_gap_scheduler_fetcher.py
+++ b/tests/test_gap_scheduler_fetcher.py
@@ -1,0 +1,64 @@
+import asyncio
+import datetime as dt
+import pandas as pd
+import pytest
+
+import db
+import scheduler
+from services import polygon_client
+from services.price_store import detect_gaps, get_prices_from_db
+
+
+async def run_job(monkeypatch, tmp_path, df_return, capture=None):
+    db.DB_PATH = str(tmp_path / "gap.db")
+    db.init_db()
+    start = pd.Timestamp("2024-01-01 19:45", tz="UTC").to_pydatetime()
+    end = pd.Timestamp("2024-01-01 20:00", tz="UTC").to_pydatetime()
+    monkeypatch.setattr(scheduler.settings, "clamp_market_closed", False)
+
+    async def fake_fetch(symbols, interval, s, e):
+        if capture is not None:
+            capture["start"] = s
+            capture["end"] = e
+        return {symbols[0]: df_return}
+    monkeypatch.setattr(polygon_client, "fetch_polygon_prices_async", fake_fetch)
+    monkeypatch.setattr(scheduler, "fetch_polygon_prices_async", fake_fetch)
+    scheduler.queue_gap_fill("AAA", start, end, "15m")
+    key, job = scheduler.work_queue.queue.get_nowait()
+    try:
+        await job()
+    finally:
+        scheduler.work_queue.queue.task_done()
+        scheduler.work_queue.keys.clear()
+    return start, end
+
+
+def test_async_context(monkeypatch, tmp_path):
+    asyncio.run(run_job(monkeypatch, tmp_path, pd.DataFrame()))
+
+
+def test_window_integrity(monkeypatch, tmp_path):
+    capture: dict = {}
+    start, end = asyncio.run(run_job(monkeypatch, tmp_path, pd.DataFrame(), capture))
+    assert capture["start"] == start
+    assert capture["end"] == end
+
+
+def test_fetch_empty(monkeypatch, tmp_path, caplog):
+    caplog.set_level("INFO")
+    asyncio.run(run_job(monkeypatch, tmp_path, pd.DataFrame()))
+    assert any("fetch_empty symbol=AAA" in r.message for r in caplog.records)
+
+
+def test_happy_path(monkeypatch, tmp_path):
+    df = pd.DataFrame(
+        {"Open": [1], "High": [1], "Low": [1], "Close": [1], "Volume": [1]},
+        index=[pd.Timestamp("2024-01-01 19:45", tz="UTC")],
+    )
+    asyncio.run(run_job(monkeypatch, tmp_path, df))
+    start = pd.Timestamp("2024-01-01 19:45", tz="UTC").to_pydatetime()
+    end = pd.Timestamp("2024-01-01 20:00", tz="UTC").to_pydatetime()
+    gaps = detect_gaps("AAA", start, end, "15m")
+    assert gaps == []
+    data = get_prices_from_db(["AAA"], start, end, "15m")["AAA"]
+    assert len(data) == 1

--- a/tests/test_polygon_dst.py
+++ b/tests/test_polygon_dst.py
@@ -25,17 +25,15 @@ def _capture_ms(monkeypatch, start: dt.datetime, end: dt.datetime) -> int:
 
 
 def test_dst_offsets(monkeypatch):
-    # September uses UTC-4 (DST)
     start = dt.datetime(2024, 9, 3, 12, 0, tzinfo=dt.timezone.utc)
     end = start + dt.timedelta(days=1)
     start_ms = _capture_ms(monkeypatch, start, end)
     start_dt = pd.Timestamp(start_ms, unit="ms", tz="UTC")
-    assert start_dt.hour == 4  # 00:00 NY -> 04:00 UTC
+    assert start_dt == pd.Timestamp(start)
 
-    # January uses UTC-5 (standard time)
     start = dt.datetime(2024, 1, 3, 12, 0, tzinfo=dt.timezone.utc)
     end = start + dt.timedelta(days=1)
     start_ms = _capture_ms(monkeypatch, start, end)
     start_dt = pd.Timestamp(start_ms, unit="ms", tz="UTC")
-    assert start_dt.hour == 5  # 00:00 NY -> 05:00 UTC
+    assert start_dt == pd.Timestamp(start)
 


### PR DESCRIPTION
## Summary
- avoid asyncio.run in gap fetch by using async polygon client
- constrain provider window exactly to scheduler requests and log ranges
- handle empty fetches gracefully and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c73dc2a9e08329aa6bfa3bb2aa3547