### PR TITLE
feat: add resilient scanner task status

### DIFF
--- a/db.py
+++ b/db.py
@@ -229,7 +229,8 @@ SCHEMA = [
         state TEXT,
         message TEXT,
         ctx TEXT,
-        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        started_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT
     );
     """,
 ]

--- a/static/js/scanner.js
+++ b/static/js/scanner.js
@@ -176,14 +176,14 @@
 
       const poll = async function(){
         try{
-          const res = await fetch(`/scanner/progress/${taskId}?t=${Date.now()}`, {cache: 'no-store'});
+          const res = await fetch(`/scanner/status/${taskId}?t=${Date.now()}`, {cache: 'no-store'});
           const data = await res.json();
           last = Date.now();
           progressFill.style.width = (data.percent || 0) + '%';
           progressText.textContent = Math.floor(data.percent || 0) + '%';
           if(data.state === 'running'){
-            pollTimer = setTimeout(poll, 1000);
-          }else if(data.state === 'done'){
+            pollTimer = setTimeout(poll, 2000);
+          }else if(data.state === 'succeeded'){
             progressFill.style.width = '100%';
             progressText.textContent = '100%';
             try{

--- a/tests/test_scanner_integration.py
+++ b/tests/test_scanner_integration.py
@@ -45,17 +45,17 @@ def test_scanner_progress_and_results(monkeypatch):
     assert res.status_code == 200
     task_id = res.json()["task_id"]
 
-    first = client.get(f"/scanner/progress/{task_id}").json()["percent"]
+    first = client.get(f"/scanner/status/{task_id}").json()["percent"]
     assert first < 100
 
     final = None
     for _ in range(50):
-        data = client.get(f"/scanner/progress/{task_id}").json()
+        data = client.get(f"/scanner/status/{task_id}").json()
         final = data["percent"]
-        if data["state"] == "done":
+        if data["state"] == "succeeded":
             break
         time.sleep(0.02)
-    assert data["state"] == "done"
+    assert data["state"] == "succeeded"
     assert final == 100
 
     html = client.get(f"/scanner/results/{task_id}")


### PR DESCRIPTION
## Summary
- persist scanner task progress with started/updated timestamps
- add stateless `/scanner/status/{task_id}` endpoint with TTL cleanup
- poll status endpoint on client every 2s for resumable scans

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c748e8bb408329ab63802abc05c6f9