### PR TITLE
feat(scanner): accelerate no-gap coverage checks

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,7 +25,9 @@ class Settings:
     scan_http_timeout: float = float(os.getenv("SCAN_HTTP_TIMEOUT", "10"))
     scan_status_poll_ms: int = int(os.getenv("SCAN_STATUS_POLL_MS", "2000"))
     scan_progress_flush_items: int = int(os.getenv("SCAN_PROGRESS_FLUSH_ITEMS", "10"))
-    scan_progress_flush_ms: int = int(os.getenv("SCAN_PROGRESS_FLUSH_MS", "500"))
+    scan_status_flush_ms: int = int(os.getenv("SCAN_STATUS_FLUSH_MS", "500"))
+    scan_fetch_concurrency: int = int(os.getenv("SCAN_FETCH_CONCURRENCY", "8"))
+    scan_coverage_batch_size: int = int(os.getenv("SCAN_COVERAGE_BATCH_SIZE", "200"))
 
 
 settings = Settings()

--- a/db.py
+++ b/db.py
@@ -219,6 +219,7 @@ SCHEMA = [
     );
     """,
     "CREATE INDEX IF NOT EXISTS idx_bars_sym_int_ts ON bars(symbol, interval, ts);",
+    "CREATE INDEX IF NOT EXISTS bars_symbol_ts ON bars(symbol, ts);",
     # Scan tasks for cross-worker communication
     """
     CREATE TABLE IF NOT EXISTS scan_tasks (

--- a/tests/test_progress_updates.py
+++ b/tests/test_progress_updates.py
@@ -6,8 +6,12 @@ def test_perform_scan_progress_every(monkeypatch):
 
     # stub compute_scan_for_ticker
     monkeypatch.setattr(routes, "compute_scan_for_ticker", lambda t, p: {"ticker": t})
-    # no-op preload
-    monkeypatch.setattr(routes, "preload_prices", lambda t, i, l: None)
+    monkeypatch.setattr(
+        routes.price_store,
+        "bulk_coverage",
+        lambda symbols, interval, s, e: {sym: (s, e, 10**6) for sym in symbols},
+    )
+    monkeypatch.setattr(routes.price_store, "covers", lambda a, b, c, d: True)
 
     class ImmediateExecutor:
         def submit(self, fn, *args, **kwargs):

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -166,7 +166,7 @@ def test_progress_polling_does_not_hit_yahoo(monkeypatch):
     # Replace _perform_scan to issue a single Yahoo request and then return.
     def fake_perform_scan(tickers, params, sort_key, progress_cb=None):
         asyncio.run(http_client.get_json("http://test/once"))
-        return [], 0
+        return [], 0, {"symbols_no_gap": len(tickers), "symbols_gap": 0}
 
     monkeypatch.setattr(routes, "_perform_scan", fake_perform_scan)
     monkeypatch.setattr(routes, "SP100", ["AAA"])  # small universe

--- a/tests/test_scanner_integration.py
+++ b/tests/test_scanner_integration.py
@@ -36,7 +36,7 @@ def test_scanner_progress_and_results(monkeypatch):
                 "stability": 0.0,
                 "rule": "r1",
             })
-        return rows, 0
+        return rows, 0, {"symbols_no_gap": total, "symbols_gap": 0}
 
     monkeypatch.setattr(routes, "_perform_scan", fake_perform_scan)
 


### PR DESCRIPTION
## Summary
- guard scanner from bar writes on fully-covered symbols and verify with tests
- batch coverage query with configurable fetch concurrency and status flush, logging scan metrics
- add index on bars(symbol, ts) to support bulk coverage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7663b04b88329a960a5f3d66b50b1