### PR TITLE
Handle SQLite rows consistently

### DIFF
--- a/db.py
+++ b/db.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sqlite3
 from pathlib import Path
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
@@ -281,11 +281,20 @@ def _ensure_scanner_column(db: sqlite3.Cursor) -> None:
         db.connection.commit()
 
 
+def row_to_dict(row: Mapping[str, Any] | sqlite3.Row | None) -> dict[str, Any]:
+    """Convert a database row into a plain dict."""
+    if row is None:
+        return {}
+    if hasattr(row, "keys"):
+        return {k: row[k] for k in row.keys()}
+    return dict(row)
+
+
 def get_settings(db: sqlite3.Cursor) -> dict:
     _ensure_scanner_column(db)
     db.execute("SELECT * FROM settings WHERE id=1")
     row = db.fetchone()
-    return dict(row) if row else {}
+    return row_to_dict(row)
 
 
 def set_last_run(boundary_iso: str, db: sqlite3.Cursor):

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -23,7 +23,14 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 from config import settings
-from db import DB_PATH, _ensure_scanner_column, get_db, get_schema_status, get_settings
+from db import (
+    DB_PATH,
+    _ensure_scanner_column,
+    get_db,
+    get_schema_status,
+    get_settings,
+    row_to_dict,
+)
 from indices import SP100, TOP150, TOP250
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
 from scanner import compute_scan_for_ticker
@@ -96,6 +103,13 @@ def check_guardrails(
 
 
 router.include_router(archive_router)
+
+
+@router.get("/history")
+def history_redirect():
+    """Redirect legacy history link to archive."""
+    return RedirectResponse(url="/archive", status_code=308)
+
 
 scan_duration = Histogram("scan_duration_seconds", "Duration of /scanner/run requests")
 scan_tickers = Counter("scan_tickers_total", "Tickers processed by /scanner/run")
@@ -687,7 +701,7 @@ def scanner_page(request: Request):
 @router.get("/favorites", response_class=HTMLResponse)
 def favorites_page(request: Request, db=Depends(get_db)):
     db.execute("SELECT * FROM favorites ORDER BY id DESC")
-    favs = [dict(r) for r in db.fetchall()]
+    favs = [row_to_dict(r) for r in db.fetchall()]
     for f in favs:
         f["avg_roi_pct"] = f.get("roi_snapshot")
         f["hit_pct"] = f.get("hit_pct_snapshot")
@@ -802,7 +816,7 @@ def _update_forward_tests(db: sqlite3.Cursor) -> None:
                FROM forward_tests
                WHERE status IN ('queued','running')"""
     )
-    rows = [dict(r) for r in db.fetchall()]
+    rows = [row_to_dict(r) for r in db.fetchall()]
     for row in rows:
         now_iso = now_et().isoformat()
         try:
@@ -938,7 +952,7 @@ def _update_forward_tests(db: sqlite3.Cursor) -> None:
 def forward_page(request: Request, db=Depends(get_db)):
     try:
         db.execute("SELECT * FROM favorites ORDER BY id DESC")
-        favs = [dict(r) for r in db.fetchall()]
+        favs = [row_to_dict(r) for r in db.fetchall()]
         for f in favs:
             db.execute(
                 "SELECT status FROM forward_tests WHERE fav_id=? ORDER BY id DESC LIMIT 1",
@@ -954,7 +968,7 @@ def forward_page(request: Request, db=Depends(get_db)):
                    FROM forward_tests ft
                    ORDER BY ft.id DESC"""
         )
-        tests = [dict(r) for r in db.fetchall()]
+        tests = [row_to_dict(r) for r in db.fetchall()]
         ctx = {"request": request, "tests": tests, "active_tab": "forward"}
     except Exception:
         logger.exception("Failed to load forward page")

--- a/routes/archive.py
+++ b/routes/archive.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 
-from db import get_db
+from db import get_db, row_to_dict
 from utils import TZ, now_et
 
 router = APIRouter()
@@ -48,9 +48,10 @@ def _format_rule_summary(params: Dict[str, Any]) -> str:
 @router.get("/archive", response_class=HTMLResponse)
 def archive_page(request: Request, db=Depends(get_db)):
     db.execute(
-        "SELECT id, started_at, scan_type, params_json, universe, finished_at, hit_count FROM runs ORDER BY id DESC LIMIT 200"
+        "SELECT id, started_at, scan_type, params_json, universe, "
+        "finished_at, hit_count FROM runs ORDER BY id DESC LIMIT 200"
     )
-    runs = [dict(r) for r in db.fetchall()]
+    runs = [row_to_dict(r) for r in db.fetchall()]
     for r in runs:
         try:
             params = json.loads(r.get("params_json") or "{}")
@@ -80,7 +81,9 @@ def archive_page(request: Request, db=Depends(get_db)):
             r["started_display"] = f"{fmt}-{rule_summary}" if rule_summary else fmt
         except Exception:
             r["started_display"] = r["started_at"]
-    return templates.TemplateResponse("archive.html", {"request": request, "runs": runs, "active_tab": "archive"})
+    return templates.TemplateResponse(
+        "archive.html", {"request": request, "runs": runs, "active_tab": "archive"}
+    )
 
 
 @router.post("/archive/save")
@@ -101,18 +104,31 @@ async def archive_save(request: Request, db=Depends(get_db)):
 
         db.execute(
             """
-            INSERT INTO runs(started_at, scan_type, params_json, universe, finished_at, hit_count, settings_json)
+            INSERT INTO runs(
+                started_at, scan_type, params_json, universe, finished_at,
+                hit_count, settings_json
+            )
             VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            (started, scan_type, settings_json, universe, finished, len(rows), settings_json),
+            (
+                started,
+                scan_type,
+                settings_json,
+                universe,
+                finished,
+                len(rows),
+                settings_json,
+            ),
         )
         run_id = db.lastrowid
 
         for r in rows:
             db.execute(
                 """
-                INSERT INTO run_results
-                  (run_id, ticker, direction, avg_roi_pct, hit_pct, support, avg_tt, avg_dd_pct, stability, rule)
+                INSERT INTO run_results(
+                    run_id, ticker, direction, avg_roi_pct, hit_pct, support,
+                    avg_tt, avg_dd_pct, stability, rule
+                )
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
@@ -147,17 +163,33 @@ async def archive_run(request: Request, db=Depends(get_db)):
     settings_json = json.dumps(params)
     db.execute(
         """
-        INSERT INTO runs(started_at, scan_type, params_json, universe, finished_at, hit_count, settings_json)
+        INSERT INTO runs(
+            started_at, scan_type, params_json, universe, finished_at,
+            hit_count, settings_json
+        )
         VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
-        (started_at, scan_type, settings_json, ",".join(universe), now_et().isoformat(), len(rows), settings_json),
+        (
+            started_at,
+            scan_type,
+            settings_json,
+            ",".join(universe),
+            now_et().isoformat(),
+            len(rows),
+            settings_json,
+        ),
     )
     run_id = db.lastrowid
 
     for r in rows:
         db.execute(
-            """INSERT INTO run_results(run_id, ticker, direction, avg_roi_pct, hit_pct, support, avg_tt, avg_dd_pct, stability, rule)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            """
+            INSERT INTO run_results(
+                run_id, ticker, direction, avg_roi_pct, hit_pct, support,
+                avg_tt, avg_dd_pct, stability, rule
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
             (
                 run_id,
                 r.get("ticker"),
@@ -183,12 +215,19 @@ def results_from_archive(request: Request, run_id: int, db=Depends(get_db)):
         return HTMLResponse("Run not found", status_code=404)
 
     db.execute(
-        """SELECT ticker, direction, avg_roi_pct, hit_pct, support, avg_tt, avg_dd_pct, stability, rule
-           FROM run_results WHERE run_id=?""",
+        """
+        SELECT
+            ticker, direction, avg_roi_pct, hit_pct, support, avg_tt,
+            avg_dd_pct, stability, rule
+        FROM run_results WHERE run_id=?
+        """,
         (run_id,),
     )
-    rows = [dict(r) for r in db.fetchall()]
-    rows.sort(key=lambda r: (r["avg_roi_pct"], r["hit_pct"], r["support"], r["stability"]), reverse=True)
+    rows = [row_to_dict(r) for r in db.fetchall()]
+    rows.sort(
+        key=lambda r: (r["avg_roi_pct"], r["hit_pct"], r["support"], r["stability"]),
+        reverse=True,
+    )
 
     rule_summary = ""
     ran_at = ""
@@ -219,7 +258,9 @@ def results_from_archive(request: Request, run_id: int, db=Depends(get_db)):
             "request": request,
             "rows": rows,
             "scan_type": run["scan_type"],
-            "universe_count": len((run["universe"] or "").split(",")) if run["universe"] else 0,
+            "universe_count": (
+                len((run["universe"] or "").split(",")) if run["universe"] else 0
+            ),
             "run_id": run_id,
             "active_tab": "archive",
             "ran_at": ran_at,
@@ -227,4 +268,3 @@ def results_from_archive(request: Request, run_id: int, db=Depends(get_db)):
             "settings_items": settings_items,
         },
     )
-

--- a/scanner.py
+++ b/scanner.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pandas as pd
 
+from db import row_to_dict
 from services.market_data import (
     expected_bar_count,
     fetch_prices,
@@ -46,8 +47,8 @@ def _install_real_engine_adapter():
             _real_scan_single = None
             return
 
-        def _row_to_dict(row: dict, params: Dict[str, Any]) -> Dict[str, Any]:
-            out = dict(row)
+        def _row_to_dict(row: Any, params: Dict[str, Any]) -> Dict[str, Any]:
+            out = row_to_dict(row)
 
             def get(*keys, default=None):
                 for k in keys:

--- a/scheduler.py
+++ b/scheduler.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from typing import Any, Awaitable, Callable, Dict
 
 from config import settings
-from db import DB_PATH, get_settings, set_last_run
+from db import DB_PATH, get_settings, row_to_dict, set_last_run
 from prometheus_client import Counter  # type: ignore
 from routes import _update_forward_tests  # type: ignore
 from scanner import preload_prices  # type: ignore
@@ -190,7 +190,7 @@ async def favorites_loop(
                         db.execute(
                             "SELECT ticker, direction, interval, rule FROM favorites ORDER BY id DESC"
                         )
-                        favs = [dict(r) for r in db.fetchall()]
+                        favs = [row_to_dict(r) for r in db.fetchall()]
                         params: Dict[str, Any] = dict(
                             interval="15m",
                             direction="BOTH",


### PR DESCRIPTION
## Summary
- add `row_to_dict` helper for safe SQLite row conversion
- use the helper across routes and scheduler to avoid type errors
- redirect `/history` to `/archive`

## Testing
- `pre-commit run --files db.py routes/__init__.py routes/archive.py scanner.py scheduler.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7787bbe3c8329bd2c47741f5d944c