### PR TITLE
Handle SQLite rows consistently

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pandas as pd
 
+from db import row_to_dict
 from services.market_data import (
     expected_bar_count,
     fetch_prices,
@@ -46,8 +47,8 @@ def _install_real_engine_adapter():
             _real_scan_single = None
             return
 
-        def _row_to_dict(row: dict, params: Dict[str, Any]) -> Dict[str, Any]:
-            out = dict(row)
+        def _row_to_dict(row: Any, params: Dict[str, Any]) -> Dict[str, Any]:
+            out = row_to_dict(row)
 
             def get(*keys, default=None):
                 for k in keys:

--- a/scheduler.py
+++ b/scheduler.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from typing import Any, Awaitable, Callable, Dict
 
 from config import settings
-from db import DB_PATH, get_settings, set_last_run
+from db import DB_PATH, get_settings, row_to_dict, set_last_run
 from prometheus_client import Counter  # type: ignore
 from routes import _update_forward_tests  # type: ignore
 from scanner import preload_prices  # type: ignore
@@ -190,7 +190,8 @@ async def favorites_loop(
                         db.execute(
                             "SELECT ticker, direction, interval, rule FROM favorites ORDER BY id DESC"
                         )
-                        favs = [dict(r) for r in db.fetchall()]
+                        cols = [c[0] for c in db.description]
+                        favs = [row_to_dict(r, cols) for r in db.fetchall()]
                         params: Dict[str, Any] = dict(
                             interval="15m",
                             direction="BOTH",


### PR DESCRIPTION
## Summary
- add `row_to_dict` helper for safe SQLite row conversion
- use the helper across routes and scheduler to avoid type errors
- redirect `/history` to `/archive`
- restore original `patternfinder.db` to avoid committing binary diffs

## Testing
- `pre-commit run --files patternfinder.db`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7787bbe3c8329bd2c47741f5d944c