### PR TITLE
Handle tuple rows in row_to_dict

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -709,7 +709,7 @@ def scanner_page(request: Request):
 @router.get("/favorites", response_class=HTMLResponse)
 def favorites_page(request: Request, db=Depends(get_db)):
     db.execute("SELECT * FROM favorites ORDER BY id DESC")
-    favs = [row_to_dict(r) for r in db.fetchall()]
+    favs = [row_to_dict(r, db) for r in db.fetchall()]
     for f in favs:
         f["avg_roi_pct"] = f.get("roi_snapshot")
         f["hit_pct"] = f.get("hit_pct_snapshot")
@@ -824,7 +824,7 @@ def _update_forward_tests(db: sqlite3.Cursor) -> None:
                FROM forward_tests
                WHERE status IN ('queued','running')"""
     )
-    rows = [row_to_dict(r) for r in db.fetchall()]
+    rows = [row_to_dict(r, db) for r in db.fetchall()]
     for row in rows:
         now_iso = now_et().isoformat()
         try:
@@ -960,7 +960,7 @@ def _update_forward_tests(db: sqlite3.Cursor) -> None:
 def forward_page(request: Request, db=Depends(get_db)):
     try:
         db.execute("SELECT * FROM favorites ORDER BY id DESC")
-        favs = [row_to_dict(r) for r in db.fetchall()]
+        favs = [row_to_dict(r, db) for r in db.fetchall()]
         for f in favs:
             db.execute(
                 "SELECT status FROM forward_tests WHERE fav_id=? ORDER BY id DESC LIMIT 1",
@@ -976,7 +976,7 @@ def forward_page(request: Request, db=Depends(get_db)):
                    FROM forward_tests ft
                    ORDER BY ft.id DESC"""
         )
-        tests = [row_to_dict(r) for r in db.fetchall()]
+        tests = [row_to_dict(r, db) for r in db.fetchall()]
         ctx = {"request": request, "tests": tests, "active_tab": "forward"}
     except Exception:
         logger.exception("Failed to load forward page")

--- a/routes/archive.py
+++ b/routes/archive.py
@@ -51,7 +51,7 @@ def archive_page(request: Request, db=Depends(get_db)):
         "SELECT id, started_at, scan_type, params_json, universe, "
         "finished_at, hit_count FROM runs ORDER BY id DESC LIMIT 200"
     )
-    runs = [row_to_dict(r) for r in db.fetchall()]
+    runs = [row_to_dict(r, db) for r in db.fetchall()]
     for r in runs:
         try:
             params = json.loads(r.get("params_json") or "{}")
@@ -223,7 +223,7 @@ def results_from_archive(request: Request, run_id: int, db=Depends(get_db)):
         """,
         (run_id,),
     )
-    rows = [row_to_dict(r) for r in db.fetchall()]
+    rows = [row_to_dict(r, db) for r in db.fetchall()]
     rows.sort(
         key=lambda r: (r["avg_roi_pct"], r["hit_pct"], r["support"], r["stability"]),
         reverse=True,

--- a/scheduler.py
+++ b/scheduler.py
@@ -190,7 +190,7 @@ async def favorites_loop(
                         db.execute(
                             "SELECT ticker, direction, interval, rule FROM favorites ORDER BY id DESC"
                         )
-                        favs = [row_to_dict(r) for r in db.fetchall()]
+                        favs = [row_to_dict(r, db) for r in db.fetchall()]
                         params: Dict[str, Any] = dict(
                             interval="15m",
                             direction="BOTH",


### PR DESCRIPTION
## Summary
- robust row_to_dict: support tuple results using cursor descriptions
- ensure pages fetching DB rows pass cursor for proper mapping
- update scheduler and routes to use new helper

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c77f453da483298777debd0f5ae4dd