### PR TITLE
Optimize scanner concurrency and template usage

### DIFF
--- a/routes/archive.py
+++ b/routes/archive.py
@@ -82,7 +82,7 @@ def archive_page(request: Request, db=Depends(get_db)):
         except Exception:
             r["started_display"] = r["started_at"]
     return templates.TemplateResponse(
-        "archive.html", {"request": request, "runs": runs, "active_tab": "archive"}
+        request, "archive.html", {"runs": runs, "active_tab": "archive"}
     )
 
 
@@ -253,9 +253,9 @@ def results_from_archive(request: Request, run_id: int, db=Depends(get_db)):
         pass
 
     return templates.TemplateResponse(
+        request,
         "results_page.html",
         {
-            "request": request,
             "rows": rows,
             "scan_type": run["scan_type"],
             "universe_count": (

--- a/services/executor.py
+++ b/services/executor.py
@@ -1,0 +1,28 @@
+import os
+import pickle
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from multiprocessing import get_context
+
+from scanner import compute_scan_for_ticker
+
+_MODE = os.getenv("SCAN_EXECUTOR_MODE", "process").lower()
+
+
+def _picklable(fn) -> bool:
+    try:
+        pickle.dumps(fn)
+        return True
+    except Exception:
+        return False
+
+
+if _MODE == "thread" or not _picklable(compute_scan_for_ticker):
+    EXECUTOR = ThreadPoolExecutor(
+        max_workers=min(32, 4 * (os.cpu_count() or 2))
+    )
+else:
+    _MP_CTX = get_context("spawn")
+    EXECUTOR = ProcessPoolExecutor(
+        max_workers=min(os.cpu_count() or 2, 8),
+        mp_context=_MP_CTX,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("SCAN_EXECUTOR_MODE", "thread")
+
 # Ensure the project root is on the import path when running ``pytest`` directly.
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:

--- a/tests/test_favorites.py
+++ b/tests/test_favorites.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -5,6 +6,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+os.environ["SCAN_EXECUTOR_MODE"] = "thread"
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import db
@@ -84,7 +86,11 @@ def test_favorites_snapshot_values(tmp_path, monkeypatch):
             self.template = type("T", (), {"name": name})
             self.context = context
 
-    monkeypatch.setattr(routes.templates, "TemplateResponse", lambda name, ctx: DummyResponse(name, ctx))
+    monkeypatch.setattr(
+        routes.templates,
+        "TemplateResponse",
+        lambda request, name, ctx: DummyResponse(name, ctx),
+    )
     request = Request({"type": "http"})
     resp = routes.favorites_page(request, db=cur)
     fav = resp.context["favorites"][0]

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -6,6 +7,7 @@ import pandas as pd
 from starlette.requests import Request
 from pytest import approx
 
+os.environ["SCAN_EXECUTOR_MODE"] = "thread"
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import db
@@ -60,7 +62,7 @@ def test_forward_tracking_only_future_bars(tmp_path, monkeypatch):
             self.template = type("T", (), {"name": name})
             self.context = context
 
-    def dummy_template_response(name, context):
+    def dummy_template_response(request, name, context):
         return DummyResponse(name, context)
 
     monkeypatch.setattr(routes.templates, "TemplateResponse", dummy_template_response)

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,7 +1,9 @@
+import os
 import sys
 from pathlib import Path
 from starlette.requests import Request
 
+os.environ["SCAN_EXECUTOR_MODE"] = "thread"
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from routes import info_page, templates
@@ -13,7 +15,7 @@ def test_info_page_uses_template(monkeypatch):
             self.template = type("T", (), {"name": name})
             self.context = context
 
-    def dummy_template_response(name, context):
+    def dummy_template_response(request, name, context):
         return DummyResponse(name, context)
 
     monkeypatch.setattr(templates, "TemplateResponse", dummy_template_response)

--- a/tests/test_progress_updates.py
+++ b/tests/test_progress_updates.py
@@ -1,3 +1,5 @@
+import os
+os.environ["SCAN_EXECUTOR_MODE"] = "thread"
 import routes
 from concurrent.futures import Future
 
@@ -21,7 +23,7 @@ def test_perform_scan_progress_every(monkeypatch):
             except Exception as e:
                 fut.set_exception(e)
             return fut
-    monkeypatch.setattr(routes, "_get_scan_executor", lambda: ImmediateExecutor())
+    monkeypatch.setattr(routes.executor, "EXECUTOR", ImmediateExecutor())
 
     updates = []
 

--- a/tests/test_scan_timing.py
+++ b/tests/test_scan_timing.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+os.environ["SCAN_EXECUTOR_MODE"] = "thread"
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import routes
+
+
+@pytest.mark.slow
+def test_scan_completes_quickly(monkeypatch):
+    tickers = [f"T{i}" for i in range(50)]
+
+    def fake_scan(t, params):
+        time.sleep(0.01)
+        return {"ticker": t}
+
+    monkeypatch.setattr(routes, "compute_scan_for_ticker", fake_scan)
+    monkeypatch.setattr(
+        routes.price_store,
+        "bulk_coverage",
+        lambda symbols, interval, s, e: {sym: (s, e, 10**6) for sym in symbols},
+    )
+    monkeypatch.setattr(routes.price_store, "covers", lambda a, b, c, d: True)
+
+    start = time.perf_counter()
+    rows, skipped, metrics = routes._perform_scan(tickers, {}, "")
+    duration = time.perf_counter() - start
+    assert len(rows) == 50
+    assert skipped == 0
+    assert duration < 2.0

--- a/tests/test_scanner_parallel.py
+++ b/tests/test_scanner_parallel.py
@@ -1,15 +1,15 @@
 import logging
+import os
 import sys
 from pathlib import Path
 
+os.environ["SCAN_EXECUTOR_MODE"] = "thread"
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import routes
 
 
 def test_scanner_run_parallel_handles_errors(monkeypatch, caplog):
-    monkeypatch.setenv("SCAN_WORKERS", "2")
-
     tickers = ["AAA", "BAD", "CCC"]
 
     def fake_scan(ticker, params):

--- a/tests/test_scanner_safeguards.py
+++ b/tests/test_scanner_safeguards.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime as dt
+import os
 import sqlite3
 import time
 
@@ -8,6 +9,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+os.environ["SCAN_EXECUTOR_MODE"] = "thread"
 import db
 import routes
 import scheduler

--- a/tests/test_skip_missing_data.py
+++ b/tests/test_skip_missing_data.py
@@ -1,9 +1,11 @@
 import logging
+import os
 import sys
 from pathlib import Path
 
 import pandas as pd
 
+os.environ["SCAN_EXECUTOR_MODE"] = "thread"
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import routes


### PR DESCRIPTION
## Summary
- add spawn-based process pool executor with thread fallback and feature flag
- batch scan results and guard writes against the bars table
- update Starlette TemplateResponse calls to new request-first style

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c78b4c70008329ac7498295e33a006