### PR TITLE
Scanner throughput on 3-core VPS — configurable workers + symbol batching (no logic change, no `bars` edits)

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,6 +28,7 @@ class Settings:
     scan_status_flush_ms: int = int(os.getenv("SCAN_STATUS_FLUSH_MS", "500"))
     scan_fetch_concurrency: int = int(os.getenv("SCAN_FETCH_CONCURRENCY", "8"))
     scan_coverage_batch_size: int = int(os.getenv("SCAN_COVERAGE_BATCH_SIZE", "200"))
+    scan_symbols_per_task: int = int(os.getenv("SCAN_SYMBOLS_PER_TASK", "1"))
 
 
 settings = Settings()

--- a/db.py
+++ b/db.py
@@ -303,7 +303,7 @@ def row_to_dict(
     if row is None:
         return {}
     if hasattr(row, "keys"):
-        return {k: row[k] for k in row.keys()}
+        return {k: row[k] for k in row.keys()}  # type: ignore[index]
     if cursor is not None and getattr(cursor, "description", None):
         cols = [c[0] for c in cursor.description]
         return {col: row[idx] for idx, col in enumerate(cols)}

--- a/services/executor.py
+++ b/services/executor.py
@@ -1,11 +1,17 @@
+import logging
 import os
 import pickle
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
 from multiprocessing import get_context
 
 from scanner import compute_scan_for_ticker
 
-_MODE = os.getenv("SCAN_EXECUTOR_MODE", "process").lower()
+
+def _max_workers(default_cap: int = 8) -> int:
+    import os as _os
+
+    cap = int(os.getenv("EXECUTOR_MAX_WORKERS", "0") or 0)
+    return cap if cap > 0 else min(_os.cpu_count() or 2, default_cap)
 
 
 def _picklable(fn) -> bool:
@@ -16,13 +22,17 @@ def _picklable(fn) -> bool:
         return False
 
 
+_MODE = os.getenv("SCAN_EXECUTOR_MODE", "process").lower()
+_LOGGER = logging.getLogger(__name__)
+
 if _MODE == "thread" or not _picklable(compute_scan_for_ticker):
-    EXECUTOR = ThreadPoolExecutor(
-        max_workers=min(32, 4 * (os.cpu_count() or 2))
-    )
+    MODE = "thread"
+    WORKERS = _max_workers(32)
+    EXECUTOR: Executor = ThreadPoolExecutor(max_workers=WORKERS)
 else:
+    MODE = "process"
     _MP_CTX = get_context("spawn")
-    EXECUTOR = ProcessPoolExecutor(
-        max_workers=min(os.cpu_count() or 2, 8),
-        mp_context=_MP_CTX,
-    )
+    WORKERS = _max_workers()
+    EXECUTOR = ProcessPoolExecutor(max_workers=WORKERS, mp_context=_MP_CTX)
+
+_LOGGER.info("executor mode=%s workers=%d", MODE, WORKERS)

--- a/tests/test_executor_env.py
+++ b/tests/test_executor_env.py
@@ -1,0 +1,40 @@
+import importlib
+import logging
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_executor_and_chunk_env(monkeypatch, caplog):
+    monkeypatch.setenv("EXECUTOR_MAX_WORKERS", "5")
+    monkeypatch.setenv("SCAN_EXECUTOR_MODE", "thread")
+    with caplog.at_level(logging.INFO):
+        ex = importlib.import_module("services.executor")
+        importlib.reload(ex)
+    assert ex.WORKERS == 5
+    assert ex.MODE == "thread"
+    assert any(
+        "executor mode=thread workers=5" in rec.message for rec in caplog.records
+    )
+
+    monkeypatch.setenv("SCAN_SYMBOLS_PER_TASK", "7")
+    import config
+
+    importlib.reload(config)
+    assert config.settings.scan_symbols_per_task == 7
+
+    routes = importlib.import_module("routes")
+
+    monkeypatch.setattr(routes, "compute_scan_for_ticker", lambda t, p: {"ticker": t})
+    monkeypatch.setattr(
+        routes.price_store,
+        "bulk_coverage",
+        lambda symbols, interval, s, e: {sym: (s, e, 10**6) for sym in symbols},
+    )
+    monkeypatch.setattr(routes.price_store, "covers", lambda a, b, c, d: True)
+    monkeypatch.setattr(routes.settings, "scan_symbols_per_task", 7, raising=False)
+
+    with caplog.at_level(logging.INFO):
+        routes._perform_scan(["AAA"], {}, "")
+    assert any("symbols_per_task=7" in rec.message for rec in caplog.records)

--- a/tests/test_scan_chunking.py
+++ b/tests/test_scan_chunking.py
@@ -1,0 +1,39 @@
+import importlib
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.mark.slow
+def test_chunking_reduces_futures(monkeypatch):
+    tickers = [f"T{i}" for i in range(9)]
+
+    routes = importlib.import_module("routes")
+    executor = importlib.import_module("services.executor")
+
+    monkeypatch.setattr(routes, "compute_scan_for_ticker", lambda t, p: {"ticker": t})
+    monkeypatch.setattr(
+        routes.price_store,
+        "bulk_coverage",
+        lambda symbols, interval, s, e: {sym: (s, e, 10**6) for sym in symbols},
+    )
+    monkeypatch.setattr(routes.price_store, "covers", lambda a, b, c, d: True)
+    monkeypatch.setattr(routes.settings, "scan_symbols_per_task", 3, raising=False)
+
+    submissions = []
+    orig_submit = executor.EXECUTOR.submit
+
+    def submit(fn, *args, **kwargs):
+        submissions.append(1)
+        return orig_submit(fn, *args, **kwargs)
+
+    monkeypatch.setattr(executor.EXECUTOR, "submit", submit)
+
+    rows, skipped, _ = routes._perform_scan(tickers, {}, "")
+    assert {r["ticker"] for r in rows} == set(tickers)
+    assert skipped == 0
+    assert len(submissions) == math.ceil(len(tickers) / 3)


### PR DESCRIPTION
## Summary
- make executor worker count configurable via `EXECUTOR_MAX_WORKERS` and log mode/worker count
- batch symbols per task using `SCAN_SYMBOLS_PER_TASK` with sequential chunk processing and progress logging
- add tests covering env-based configuration and batching behavior

## Testing
- `pre-commit run --files services/executor.py config.py routes/__init__.py db.py tests/test_executor_env.py tests/test_scan_chunking.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c79ee1cd8c8329868c70f013ec7b7c