### PR TITLE
Wire up real SMTP sending for Favorites Test Alert (use Settings), add required fields + error handling

### DIFF
--- a/db.py
+++ b/db.py
@@ -65,8 +65,11 @@ SCHEMA = [
     """
     CREATE TABLE IF NOT EXISTS settings (
         id INTEGER PRIMARY KEY CHECK (id=1),
+        smtp_host TEXT,
+        smtp_port INTEGER DEFAULT 587,
         smtp_user TEXT,
         smtp_pass TEXT,
+        mail_from TEXT,
         recipients TEXT,
         scanner_recipients TEXT,
         scheduler_enabled INTEGER DEFAULT 0,
@@ -80,8 +83,11 @@ SCHEMA = [
     INSERT OR IGNORE INTO settings
       (
         id,
+        smtp_host,
+        smtp_port,
         smtp_user,
         smtp_pass,
+        mail_from,
         recipients,
         scanner_recipients,
         scheduler_enabled,
@@ -90,7 +96,7 @@ SCHEMA = [
         last_run_at
       )
     VALUES
-      (1, '', '', '', '', 0, 60, '', '');
+      (1, '', 587, '', '', '', '', '', 0, 60, '', '');
     """,
     # Favorites
     """
@@ -287,6 +293,15 @@ def _ensure_scanner_column(db: sqlite3.Cursor) -> None:
         db.execute(
             "ALTER TABLE settings ADD COLUMN greeks_profile_json TEXT DEFAULT '{}'"
         )
+        db.connection.commit()
+    if "smtp_host" not in cols:
+        db.execute("ALTER TABLE settings ADD COLUMN smtp_host TEXT DEFAULT ''")
+        db.connection.commit()
+    if "smtp_port" not in cols:
+        db.execute("ALTER TABLE settings ADD COLUMN smtp_port INTEGER DEFAULT 587")
+        db.connection.commit()
+    if "mail_from" not in cols:
+        db.execute("ALTER TABLE settings ADD COLUMN mail_from TEXT DEFAULT ''")
         db.connection.commit()
 
 

--- a/services/favorites_alerts.py
+++ b/services/favorites_alerts.py
@@ -294,7 +294,7 @@ def enrich_and_send(hit: FavoriteHitStub, is_test: bool = False) -> bool:  # pra
 
 def enrich_and_send_test(
     ticker: str, direction: str, channel: str = "mms", compact: bool = False
-) -> tuple[bool, str]:
+) -> tuple[bool, dict[str, str]]:
     fake_hit = FavoriteHitStub(ticker=ticker, direction=direction, pattern="Manual Test")
     contract = options_provider.OptionContract(
         occ="TEST",
@@ -318,4 +318,5 @@ def enrich_and_send_test(
     checks = [Check("Delta", "Δ", 0.0, True)]
     profile = {"compact_mms": compact, "include_symbols_in_alerts": True}
     body = format_mms(fake_hit, contract, checks, profile)
-    return True, body
+    subject = f"Favorites Alert Test: {ticker.upper()} {direction.upper()}"
+    return True, {"subject": subject, "body": body}

--- a/services/notify.py
+++ b/services/notify.py
@@ -1,0 +1,54 @@
+"""Notification helpers for sending email via SMTP."""
+from __future__ import annotations
+
+import smtplib
+import ssl
+from email.message import EmailMessage
+from email.utils import formatdate, make_msgid, parseaddr
+from typing import Any, Dict, List
+
+import certifi
+
+
+def send_email_smtp(
+    host: str,
+    port: int,
+    user: str,
+    password: str,
+    mail_from: str,
+    to: List[str],
+    subject: str,
+    body: str,
+) -> Dict[str, Any]:
+    """Send an email using SMTP with STARTTLS.
+
+    Parameters mirror the fields stored in the ``settings`` table.  The
+    connection uses STARTTLS which is compatible with providers such as Gmail
+    when ``port`` is 587.
+    """
+
+    display_name, from_email = parseaddr(mail_from)
+    domain_hint = from_email.split("@", 1)[-1] if "@" in from_email else None
+    message_id = make_msgid(domain=domain_hint)
+    msg = EmailMessage()
+    msg["Message-ID"] = message_id
+    msg["Date"] = formatdate(localtime=True)
+    msg["Subject"] = subject
+    msg["From"] = mail_from or user
+    msg["To"] = ", ".join(to)
+    msg.set_content(body)
+
+    context = ssl.create_default_context(cafile=certifi.where())
+
+    try:
+        with smtplib.SMTP(host, int(port), timeout=20) as server:
+            server.ehlo()
+            server.starttls(context=context)
+            server.ehlo()
+            if user:
+                server.login(user, password)
+            server.send_message(msg, from_addr=from_email or user, to_addrs=to)
+    except Exception as exc:  # pragma: no cover - network interaction
+        return {"ok": False, "error": str(exc)}
+
+    return {"ok": True, "provider": "smtp", "message_id": message_id}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,17 +1,67 @@
 {% extends 'base.html' %}
 {% block title %}Pattern Finder — Settings{% endblock %}
+{% block head_extra %}
+<style>
+  #fav-preview-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(7, 16, 30, 0.75);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+  }
+  #fav-preview-modal.hidden { display: none; }
+  #fav-preview-modal .modal-content {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 20px;
+    max-width: 520px;
+    width: min(92%, 520px);
+    box-shadow: 0 24px 60px rgba(0,0,0,.45);
+  }
+  #fav-preview-modal h3 { margin-top: 0; }
+  #fav-preview-body {
+    background: #070a12;
+    border-radius: 10px;
+    padding: 12px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 320px;
+    overflow-y: auto;
+  }
+  #fav-preview-meta { color: var(--muted); margin-bottom: .75rem; font-size: .95rem; }
+  #fav-preview-modal .actions { justify-content: flex-end; }
+  #fav-test-status { min-height: 1.5rem; }
+  .status-success { color: var(--pos); }
+  .status-error { color: var(--neg); }
+</style>
+{% endblock %}
 {% block content %}
   <div class="card">
     <h1 style="margin-top:0;">Settings</h1>
     <form action="/settings/save" method="post">
       <div class="grid">
         <div>
+          <label>SMTP Host</label>
+          <input name="smtp_host" value="{{ st['smtp_host'] or '' }}" placeholder="smtp.gmail.com" />
+        </div>
+        <div>
+          <label>SMTP Port</label>
+          <input name="smtp_port" type="number" step="1" value="{{ st['smtp_port'] or 587 }}" />
+        </div>
+        <div>
+          <label>Mail From</label>
+          <input name="mail_from" value="{{ st['mail_from'] or '' }}" placeholder="Petra Alerts &lt;petrastockalerts@gmail.com&gt;" />
+        </div>
+        <div>
           <label>SMTP User</label>
           <input name="smtp_user" value="{{ st['smtp_user'] or '' }}" />
         </div>
         <div>
           <label>SMTP Pass</label>
-          <input name="smtp_pass" type="password" value="{{ st['smtp_pass'] or '' }}" />
+          <input name="smtp_pass" type="password" value="{{ st['smtp_pass'] or '' }}" autocomplete="off" />
         </div>
         <div>
           <label>Scanner Results Recipients (comma-separated)</label>
@@ -33,6 +83,9 @@
           <input name="throttle_minutes" type="number" step="1" value="{{ st['throttle_minutes'] or 60 }}" />
         </div>
       </div>
+      {% if smtp_warning %}
+      <p class="note status-error" style="margin-top:.5rem;">SMTP configuration incomplete: {{ smtp_missing_label }}</p>
+      {% endif %}
 
   <div class="actions">
     <button type="submit">Save</button>
@@ -54,8 +107,8 @@
         <div>
           <label>Channel</label>
           <select id="fav-test-channel">
-            <option value="mms">MMS</option>
-            <option value="email">Email</option>
+            <option value="email" {% if smtp_configured %}selected{% endif %}>Email</option>
+            <option value="mms" {% if not smtp_configured %}selected{% endif %} {% if not twilio_configured %}disabled title="MMS requires Twilio configuration"{% endif %}>MMS</option>
           </select>
         </div>
         <div>
@@ -66,17 +119,147 @@
           </select>
         </div>
       </div>
-      <button id="fav-test-send" class="btn" style="margin-top:.5rem;">Send Test Alert</button>
+      <p id="fav-test-status" class="note" style="margin-top:.75rem;"></p>
+      <button id="fav-test-send" class="btn" style="margin-top:.25rem;">Send Test Alert</button>
+    </div>
+  </div>
+  <div id="fav-preview-modal" class="hidden">
+    <div class="modal-content">
+      <h3>Favorites Test Alert Preview</h3>
+      <div id="fav-preview-meta"></div>
+      <pre id="fav-preview-body"></pre>
+      <div class="actions" style="margin-top:1rem;">
+        <button id="fav-preview-cancel" type="button" class="btn">Cancel</button>
+        <button id="fav-preview-send" type="button">Send Alert</button>
+      </div>
     </div>
   </div>
 {% endblock %}
 {% block extra_body %}
 <script>
-  document.getElementById('fav-test-send')?.addEventListener('click', async ()=>{
-    const symbol = document.getElementById('fav-test-symbol').value || 'AAPL';
-    const channel = document.getElementById('fav-test-channel').value || 'mms';
-    const compact = document.getElementById('fav-test-compact').value === '1';
-    await fetch('/favorites/test_alert',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({symbol,channel,compact})});
-  });
+  (function(){
+    const sendBtn = document.getElementById('fav-test-send');
+    const symbolInput = document.getElementById('fav-test-symbol');
+    const channelInput = document.getElementById('fav-test-channel');
+    const compactInput = document.getElementById('fav-test-compact');
+    const statusEl = document.getElementById('fav-test-status');
+    const modal = document.getElementById('fav-preview-modal');
+    const modalBody = document.getElementById('fav-preview-body');
+    const modalMeta = document.getElementById('fav-preview-meta');
+    const modalSend = document.getElementById('fav-preview-send');
+    const modalCancel = document.getElementById('fav-preview-cancel');
+    let pendingPayload = null;
+
+    function setStatus(message, tone) {
+      if (!statusEl) return;
+      statusEl.textContent = message || '';
+      statusEl.classList.remove('status-error','status-success');
+      if (!message) {
+        statusEl.style.visibility = 'hidden';
+        return;
+      }
+      statusEl.style.visibility = 'visible';
+      if (tone === 'error') {
+        statusEl.classList.add('status-error');
+      } else if (tone === 'success') {
+        statusEl.classList.add('status-success');
+      }
+    }
+
+    function openModal(subject, body) {
+      modal?.classList.remove('hidden');
+      modalBody.textContent = body || '';
+      modalMeta.textContent = subject ? `Subject: ${subject}` : 'Subject: (none)';
+    }
+
+    function closeModal() {
+      modal?.classList.add('hidden');
+    }
+
+    async function fetchPreview(payload) {
+      const res = await fetch('/favorites/test_alert/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) {
+        const err = data.error || 'Unable to generate preview';
+        throw new Error(err);
+      }
+      return data;
+    }
+
+    async function sendAlert(payload) {
+      const res = await fetch('/favorites/test_alert', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) {
+        const err = data.error || 'Alert send failed';
+        throw new Error(err);
+      }
+      return data;
+    }
+
+    sendBtn?.addEventListener('click', async () => {
+      const symbol = (symbolInput?.value || 'AAPL').trim().toUpperCase();
+      const channel = channelInput?.value || 'mms';
+      const compact = (compactInput?.value || '0') === '1';
+      const payload = { symbol, channel, compact };
+      pendingPayload = payload;
+      setStatus('Generating preview…');
+      sendBtn.disabled = true;
+      try {
+        const preview = await fetchPreview(payload);
+        openModal(preview.subject || `Favorites Alert Test: ${symbol}`, preview.body || '');
+        setStatus('Preview ready — review before sending.');
+      } catch (err) {
+        setStatus(err.message || 'Failed to load preview', 'error');
+      } finally {
+        sendBtn.disabled = false;
+      }
+    });
+
+    modalSend?.addEventListener('click', async () => {
+      if (!pendingPayload) {
+        closeModal();
+        return;
+      }
+      modalSend.disabled = true;
+      sendBtn.disabled = true;
+      setStatus('Sending alert…');
+      try {
+        const result = await sendAlert(pendingPayload);
+        const msgId = result.message_id ? `message-id ${result.message_id}` : 'sent';
+        setStatus(`Sent (${msgId})`, 'success');
+      } catch (err) {
+        setStatus(err.message || 'Failed to send alert', 'error');
+      } finally {
+        modalSend.disabled = false;
+        sendBtn.disabled = false;
+        closeModal();
+        pendingPayload = null;
+      }
+    });
+
+    modalCancel?.addEventListener('click', () => {
+      closeModal();
+      pendingPayload = null;
+      setStatus('Preview cancelled');
+    });
+
+    modal?.addEventListener('click', (event) => {
+      if (event.target === modal) {
+        closeModal();
+        pendingPayload = null;
+        setStatus('Preview cancelled');
+      }
+    });
+
+    setStatus('');
+  })();
 </script>
 {% endblock %}

--- a/tests/test_favorites_test_alert.py
+++ b/tests/test_favorites_test_alert.py
@@ -9,12 +9,16 @@ import routes
 def setup_app(tmp_path, monkeypatch):
     db.DB_PATH = str(tmp_path / "test.db")
     db.init_db()
-    telem = {}
-    monkeypatch.setattr(routes, "log_telemetry", lambda e: telem.update(e))
+    events = []
+
+    def record(event):
+        events.append(event)
+
+    monkeypatch.setattr(routes, "log_telemetry", record)
     app = FastAPI()
     app.include_router(routes.router)
     client = TestClient(app)
-    return client, telem
+    return client, events
 
 
 def test_favorites_test_alert_mms(tmp_path, monkeypatch):
@@ -22,10 +26,10 @@ def test_favorites_test_alert_mms(tmp_path, monkeypatch):
 
     def fake_enrich(symbol, direction, channel="mms", compact=False):
         called.update({"symbol": symbol, "channel": channel, "compact": compact})
-        return True, f"{symbol} {direction}\nWhy this contract: Δ 0.00"
+        return True, {"subject": "Test Subject", "body": f"{symbol} {direction}\nWhy this contract: Δ 0.00"}
 
     monkeypatch.setattr(routes.favorites_alerts, "enrich_and_send_test", fake_enrich)
-    client, telem = setup_app(tmp_path, monkeypatch)
+    client, events = setup_app(tmp_path, monkeypatch)
     res = client.post(
         "/favorites/test_alert",
         json={"symbol": "AAPL", "channel": "mms", "compact": False},
@@ -33,8 +37,9 @@ def test_favorites_test_alert_mms(tmp_path, monkeypatch):
     assert res.status_code == 200
     data = res.json()
     assert "Why this contract" in data["body"]
+    assert data["subject"] == "Test Subject"
     assert called["channel"] == "mms"
-    assert telem == {
+    assert events[-1] == {
         "type": "favorites_test_alert",
         "symbol": "AAPL",
         "channel": "mms",
@@ -43,28 +48,160 @@ def test_favorites_test_alert_mms(tmp_path, monkeypatch):
     }
 
 
-def test_favorites_test_alert_email(tmp_path, monkeypatch):
+def test_test_alert_email_success_returns_message_id(tmp_path, monkeypatch):
     called = {}
 
     def fake_enrich(symbol, direction, channel="mms", compact=False):
         called.update({"symbol": symbol, "channel": channel, "compact": compact})
-        return True, f"{symbol} {direction}\nWhy this contract: Δ 0.00"
+        return True, {"subject": "Email Subject", "body": "Line 1\nLine 2"}
 
     monkeypatch.setattr(routes.favorites_alerts, "enrich_and_send_test", fake_enrich)
-    client, telem = setup_app(tmp_path, monkeypatch)
+
+    sent_call = {}
+
+    def fake_send(host, port, user, password, mail_from, to, subject, body):
+        sent_call.update(
+            {
+                "host": host,
+                "port": port,
+                "user": user,
+                "password": password,
+                "mail_from": mail_from,
+                "to": to,
+                "subject": subject,
+                "body": body,
+            }
+        )
+        return {"ok": True, "provider": "smtp", "message_id": "<msg-123>"}
+
+    monkeypatch.setattr(routes, "send_email_smtp", fake_send)
+
+    client, events = setup_app(tmp_path, monkeypatch)
+
+    conn = sqlite3.connect(db.DB_PATH)
+    conn.execute(
+        """
+        UPDATE settings
+           SET smtp_host=?, smtp_port=?, smtp_user=?, smtp_pass=?, mail_from=?, recipients=?
+         WHERE id=1
+        """,
+        (
+            "smtp.gmail.com",
+            587,
+            "alerts@gmail.com",
+            "app-pass",
+            "Petra Alerts <alerts@gmail.com>",
+            "test@example.com",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
     res = client.post(
         "/favorites/test_alert",
         json={"symbol": "AAPL", "channel": "email", "compact": True},
     )
     assert res.status_code == 200
     data = res.json()
-    assert "Why this contract" in data["body"]
+    assert data["ok"] is True
+    assert data["message_id"] == "<msg-123>"
+    assert data["subject"] == "Email Subject"
     assert called["channel"] == "email"
     assert called["compact"] is True
-    assert telem == {
+    assert sent_call == {
+        "host": "smtp.gmail.com",
+        "port": 587,
+        "user": "alerts@gmail.com",
+        "password": "app-pass",
+        "mail_from": "Petra Alerts <alerts@gmail.com>",
+        "to": ["test@example.com"],
+        "subject": "Email Subject",
+        "body": "Line 1\nLine 2",
+    }
+    assert events[-2] == {
+        "type": "favorites_test_alert_send",
+        "channel": "email",
+        "provider": "smtp",
+        "ok": True,
+        "message_id": "<msg-123>",
+    }
+    assert events[-1] == {
         "type": "favorites_test_alert",
         "symbol": "AAPL",
         "channel": "email",
         "compact": True,
         "ok": True,
     }
+
+
+def test_test_alert_email_missing_config_400(tmp_path, monkeypatch):
+    def fake_enrich(symbol, direction, channel="mms", compact=False):
+        return True, {"subject": "Email Subject", "body": "Preview"}
+
+    monkeypatch.setattr(routes.favorites_alerts, "enrich_and_send_test", fake_enrich)
+    client, events = setup_app(tmp_path, monkeypatch)
+
+    conn = sqlite3.connect(db.DB_PATH)
+    conn.execute(
+        """
+        UPDATE settings
+           SET smtp_port=?, smtp_user=?, smtp_pass=?, mail_from=?, recipients=?
+         WHERE id=1
+        """,
+        (
+            587,
+            "alerts@gmail.com",
+            "app-pass",
+            "Petra Alerts <alerts@gmail.com>",
+            "test@example.com",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    res = client.post(
+        "/favorites/test_alert",
+        json={"symbol": "AAPL", "channel": "email", "compact": False},
+    )
+    assert res.status_code == 400
+    data = res.json()
+    assert data["ok"] is False
+    assert "SMTP not configured" in data["error"]
+    assert "SMTP host" in data["error"]
+    assert events[-2] == {
+        "type": "favorites_test_alert_send",
+        "channel": "email",
+        "provider": "smtp",
+        "ok": False,
+        "error": data["error"],
+    }
+    assert events[-1] == {
+        "type": "favorites_test_alert",
+        "symbol": "AAPL",
+        "channel": "email",
+        "compact": False,
+        "ok": False,
+    }
+
+
+def test_preview_returns_body_subject(tmp_path, monkeypatch):
+    def fake_enrich(symbol, direction, channel="mms", compact=False):
+        return True, {"subject": f"Preview {symbol}", "body": "Example body"}
+
+    monkeypatch.setattr(routes.favorites_alerts, "enrich_and_send_test", fake_enrich)
+    client, events = setup_app(tmp_path, monkeypatch)
+    res = client.post(
+        "/favorites/test_alert/preview",
+        json={"symbol": "MSFT", "channel": "email", "compact": True},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data == {
+        "ok": True,
+        "symbol": "MSFT",
+        "channel": "email",
+        "compact": True,
+        "subject": "Preview MSFT",
+        "body": "Example body",
+    }
+    assert events == []

--- a/tests/test_recipient_lists.py
+++ b/tests/test_recipient_lists.py
@@ -1,53 +1,61 @@
-import smtplib
-
-from routes import _send_email
-
-
-def _dummy_smtp(sent):
-    class DummySMTP:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def login(self, user, pwd):
-            pass
-
-        def send_message(self, msg):
-            sent.append(msg)
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            pass
-
-    return DummySMTP
+import routes
 
 
 def test_scanner_recipients_ignore_sms(monkeypatch):
     sent = []
-    dummy = _dummy_smtp(sent)
-    monkeypatch.setattr(smtplib, "SMTP_SSL", dummy)
-    monkeypatch.setattr(smtplib, "SMTP", dummy)
+
+    def fake_send(host, port, user, password, mail_from, to, subject, body):
+        sent.append({
+            "host": host,
+            "port": port,
+            "user": user,
+            "password": password,
+            "mail_from": mail_from,
+            "to": to,
+            "subject": subject,
+            "body": body,
+        })
+        return {"ok": True, "provider": "smtp", "message_id": "<id>"}
+
+    monkeypatch.setattr(routes, "send_email_smtp", fake_send)
     st = {
+        "smtp_host": "smtp.gmail.com",
+        "smtp_port": 587,
         "smtp_user": "u@example.com",
         "smtp_pass": "pw",
+        "mail_from": "u@example.com",
         "scanner_recipients": "user@example.com, 5551234567@txt.att.net",
     }
-    _send_email(st, "sub", "body", list_field="scanner_recipients", allow_sms=False)
+    routes._send_email(st, "sub", "body", list_field="scanner_recipients", allow_sms=False)
     assert len(sent) == 1
-    assert sent[0]["To"] == "user@example.com"
+    assert sent[0]["to"] == ["user@example.com"]
 
 
 def test_favorites_recipients_allow_sms(monkeypatch):
     sent = []
-    dummy = _dummy_smtp(sent)
-    monkeypatch.setattr(smtplib, "SMTP_SSL", dummy)
-    monkeypatch.setattr(smtplib, "SMTP", dummy)
+
+    def fake_send(host, port, user, password, mail_from, to, subject, body):
+        sent.append({
+            "host": host,
+            "port": port,
+            "user": user,
+            "password": password,
+            "mail_from": mail_from,
+            "to": to,
+            "subject": subject,
+            "body": body,
+        })
+        return {"ok": True, "provider": "smtp", "message_id": "<id>"}
+
+    monkeypatch.setattr(routes, "send_email_smtp", fake_send)
     st = {
+        "smtp_host": "smtp.gmail.com",
+        "smtp_port": 587,
         "smtp_user": "u@example.com",
         "smtp_pass": "pw",
+        "mail_from": "u@example.com",
         "recipients": "user@example.com, 5551234567@txt.att.net",
     }
-    _send_email(st, "sub", "body")
+    routes._send_email(st, "sub", "body")
     assert len(sent) == 1
-    assert sent[0]["To"] == "user@example.com, 5551234567@txt.att.net"
+    assert sent[0]["to"] == ["user@example.com", "5551234567@txt.att.net"]


### PR DESCRIPTION
## Summary
- extend the settings schema/UI with SMTP host, port and mail-from fields plus inline warnings when configuration is partial
- add `services.notify.send_email_smtp` and update the favorites test alert endpoint to validate settings, send real email, log message IDs, and expose a preview endpoint with UI modal support
- refactor the shared `_send_email` helper to use the new SMTP path and update automated tests for email/mms recipient handling and the new API behaviours

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c841d23eec8329a9b267356ff516ba