### PR TITLE
Add soft-delete controls for overnight batches

### DIFF
--- a/alembic/versions/0004_favorites_lookback_backfill.py
+++ b/alembic/versions/0004_favorites_lookback_backfill.py
@@ -1,0 +1,39 @@
+"""Backfill favorites lookback values
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2024-09-01 00:00:00.000000
+"""
+from __future__ import annotations
+
+try:  # pragma: no cover - prefer real Alembic if available
+    from alembic import op  # type: ignore
+except Exception:  # pragma: no cover - fallback stub
+    from alembic_stub import op
+
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    cols = [row[1] for row in conn.exec_driver_sql("PRAGMA table_info(favorites)").fetchall()]
+    if "lookback_years" not in cols:
+        op.execute("ALTER TABLE favorites ADD COLUMN lookback_years REAL")
+
+    op.execute(
+        """
+        UPDATE favorites
+           SET lookback_years = CAST(json_extract(support_snapshot, '$.lookback_years') AS REAL)
+         WHERE (lookback_years IS NULL OR lookback_years IN (0, 0.2))
+           AND json_type(json_extract(support_snapshot, '$.lookback_years')) IN ('integer','real');
+        """
+    )
+
+
+def downgrade() -> None:
+    raise RuntimeError("downgrade not supported")
+

--- a/alembic/versions/0005_overnight_soft_delete.py
+++ b/alembic/versions/0005_overnight_soft_delete.py
@@ -1,0 +1,25 @@
+"""add deleted_at to overnight batches
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2024-09-15 00:00:00.000000
+"""
+from __future__ import annotations
+
+try:
+    from alembic import op  # type: ignore
+except Exception:  # pragma: no cover - fallback stub
+    from alembic_stub import op
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE overnight_batches ADD COLUMN deleted_at TEXT")
+
+
+def downgrade() -> None:
+    raise RuntimeError("downgrade not supported")

--- a/static/js/overnight.js
+++ b/static/js/overnight.js
@@ -5,11 +5,15 @@
   const startBtn = document.getElementById('start-now');
   const tmpl = document.getElementById('row-template');
   const batchesDiv = document.getElementById('batches');
+  const showFinished = document.getElementById('show-finished');
+  const clearFinishedBtn = document.getElementById('clear-finished');
   const winStart = document.getElementById('win-start');
   const winEnd = document.getElementById('win-end');
   const savePrefs = document.getElementById('save-prefs');
   const winInfo = document.getElementById('window-info');
   let windowNotice = '';
+  const FINISHED_STATUSES = new Set(['complete', 'canceled', 'failed']);
+  const REMOVAL_CONFIRM = 'Remove finished batch? CSV links may no longer be shown on this page, but data already exported remains.';
 
   function renumber(){
     [...queue.children].forEach((row, idx)=>{
@@ -45,10 +49,36 @@
     loadBatches();
   });
 
-  async function loadBatches(){
-    const res = await fetch('/overnight/batches');
+  function renderBatch(b){
+    const finished = FINISHED_STATUSES.has(b.status);
+    const actions = [];
+    if(!finished){
+      actions.push(`<button class="start" ${b.status==='running'?'disabled':''}>Start Now</button>`);
+      actions.push('<button class="pause">Pause</button>');
+      actions.push('<button class="resume">Resume</button>');
+      actions.push('<button class="cancel">Cancel</button>');
+    }else{
+      actions.push('<button class="remove">Remove</button>');
+    }
+    actions.push(`<a class="csv" href="/overnight/batches/${b.id}/csv">CSV</a>`);
+    return `<div class="batch ${b.status}" data-id="${b.id}" data-status="${b.status}">${b.label||b.id} - ${b.status} (${b.items_done||0}/${b.items_total||0}) <span class="win">Runs ${windowNotice}</span> ${actions.join(' ')}</div>`;
+  }
+
+  async function loadBatches(forceDefault=false){
+    if(forceDefault && showFinished){
+      showFinished.checked = false;
+    }
+    const params = new URLSearchParams();
+    if(showFinished?.checked){
+      params.set('include_finished', 'true');
+    }
+    const qs = params.toString();
+    const res = await fetch(qs ? `/overnight/batches?${qs}` : '/overnight/batches');
     const data = await res.json();
-    batchesDiv.innerHTML = data.batches.map(b=>`<div class="batch ${b.status}" data-id="${b.id}">${b.label||b.id} - ${b.status} (${b.items_done||0}/${b.items_total||0}) <span class="win">Runs ${windowNotice}</span> <button class="start" ${b.status==='running'||b.status==='complete'?'disabled':''}>Start Now</button> <button class="pause">Pause</button> <button class="resume">Resume</button> <button class="cancel">Cancel</button> <a class="csv" href="/overnight/batches/${b.id}/csv">CSV</a></div>`).join('');
+    batchesDiv.innerHTML = data.batches.map(renderBatch).join('');
+    if(clearFinishedBtn){
+      clearFinishedBtn.disabled = !data.finished_count;
+    }
   }
 
   batchesDiv.addEventListener('click', async e=>{
@@ -65,17 +95,47 @@
       if(data.status==='queued_after_current') alert('Queued after current batch');
       loadBatches();
     }else if(e.target.classList.contains('pause')){
-      await fetch(`/overnight/batches/${id}/pause`,{method:'POST'}); loadBatches();
+      await fetch(`/overnight/batches/${id}/pause`,{method:'POST'});
+      loadBatches();
     }else if(e.target.classList.contains('resume')){
-      await fetch(`/overnight/batches/${id}/resume`,{method:'POST'}); loadBatches();
+      await fetch(`/overnight/batches/${id}/resume`,{method:'POST'});
+      loadBatches();
     }else if(e.target.classList.contains('cancel')){
-      await fetch(`/overnight/batches/${id}/cancel`,{method:'POST'}); loadBatches();
+      await fetch(`/overnight/batches/${id}/cancel`,{method:'POST'});
+      loadBatches();
+    }else if(e.target.classList.contains('remove')){
+      if(!confirm(REMOVAL_CONFIRM)) return;
+      const resp = await fetch(`/overnight/batches/${id}`,{method:'DELETE'});
+      if(resp.status===409){
+        alert('Batch is still active.');
+        return;
+      }
+      if(!resp.ok){
+        alert('Failed to remove batch.');
+        return;
+      }
+      await loadBatches(true);
     }
   });
 
   startBtn?.addEventListener('click', ()=>{
     const first = batchesDiv.querySelector('.batch');
     if(first) fetch(`/overnight/batches/${first.dataset.id}/start_now`,{method:'POST'}).then(loadBatches);
+  });
+
+  showFinished?.addEventListener('change', ()=>{
+    loadBatches();
+  });
+
+  clearFinishedBtn?.addEventListener('click', async ()=>{
+    if(clearFinishedBtn.disabled) return;
+    if(!confirm(REMOVAL_CONFIRM)) return;
+    const resp = await fetch('/overnight/batches/clear_finished',{method:'POST'});
+    if(!resp.ok){
+      alert('Failed to clear finished batches.');
+      return;
+    }
+    await loadBatches(true);
   });
 
   function updateWinInfo(pref){

--- a/templates/favorites.html
+++ b/templates/favorites.html
@@ -32,8 +32,8 @@
           <td><strong>{{ f["ticker"] }}</strong></td>
           <td>{{ f["direction"] }}</td>
           <td>{{ f["interval"] }}</td>
-          <td>{{ '{:.1f}'.format(f['lookback_years']) if f['lookback_years'] is not none else '' }}</td>
-          <td>{{ f['support_snapshot'] or f['min_support'] }}</td>
+          <td>{{ f['lookback_display'] }}</td>
+          <td>{{ f['support_display'] }}</td>
           <td>{{ '{:.0f}'.format(f['avg_roi_pct']*100 if f['avg_roi_pct'] is not none and f['avg_roi_pct'] <= 1 else f['avg_roi_pct']) if f['avg_roi_pct'] is not none else '' }}</td>
           <td>{{ '{:.1f}'.format(f['hit_pct']) if f['hit_pct'] is not none else '' }}</td>
           <td>{{ '{:.0f}'.format(f['avg_dd_pct']*100 if f['avg_dd_pct'] is not none and f['avg_dd_pct'] <= 1 else f['avg_dd_pct']) if f['avg_dd_pct'] is not none else '' }}</td>

--- a/templates/overnight.html
+++ b/templates/overnight.html
@@ -16,6 +16,10 @@
   <p class="notice">Items run one-by-one. The next starts only after the previous completes.</p>
 </div>
 <hr/>
+<div class="batch-controls">
+  <label><input type="checkbox" id="show-finished"> Show finished</label>
+  <button id="clear-finished" disabled>Clear finished</button>
+</div>
 <div id="batches"></div>
 <template id="row-template">
   <div class="ov-row">

--- a/tests/test_favorites_page.py
+++ b/tests/test_favorites_page.py
@@ -30,6 +30,6 @@ def test_favorites_list_shows_lookback_hits(tmp_path):
     text = res.text
     assert "Lookback" in text
     assert "Hits" in text
-    assert "1.5" in text
+    assert "1.5y" in text
     assert ">45<" in text
 

--- a/tests/test_forward_favorites_api.py
+++ b/tests/test_forward_favorites_api.py
@@ -37,6 +37,7 @@ def test_forward_list_favorites_present(tmp_path, monkeypatch):
     assert res.status_code == 200
     data = res.json()
     assert len(data["favorites"]) == 2
+    assert {fav["lookback_years"] for fav in data["favorites"]} == {1.0}
     page = client.get("/forward")
     assert "AAA" in page.text and "BBB" in page.text
 

--- a/tests/test_migration_0004.py
+++ b/tests/test_migration_0004.py
@@ -1,0 +1,46 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+import db
+
+
+def _alembic_config(db_path: Path) -> Config:
+    cfg = Config(str(Path(__file__).resolve().parents[1] / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def test_migration_0004_backfills_lookback(tmp_path):
+    db_path = tmp_path / "mig.db"
+    db.DB_PATH = str(db_path)
+    cfg = _alembic_config(db_path)
+
+    command.upgrade(cfg, "0003")
+
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO favorites(ticker,direction,interval,rule,lookback_years,support_snapshot) VALUES(?,?,?,?,?,?)",
+        (
+            "AAA",
+            "UP",
+            "15m",
+            "r1",
+            0.2,
+            json.dumps({"count": 20, "lookback_years": 2.5}),
+        ),
+    )
+    conn.commit()
+
+    command.upgrade(cfg, "head")
+
+    cur.execute("SELECT lookback_years FROM favorites WHERE ticker='AAA'")
+    lookback = cur.fetchone()[0]
+    conn.close()
+
+    assert lookback == 2.5
+

--- a/tests/test_migration_0005.py
+++ b/tests/test_migration_0005.py
@@ -1,0 +1,45 @@
+import sqlite3
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+import db
+
+
+def _alembic_config(db_path: Path) -> Config:
+    cfg = Config(str(Path(__file__).resolve().parents[1] / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def test_migration_0005_adds_deleted_at(tmp_path):
+    db_path = tmp_path / "mig.db"
+    db.DB_PATH = str(db_path)
+    cfg = _alembic_config(db_path)
+
+    command.upgrade(cfg, "0004")
+
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO overnight_batches(id,status) VALUES(?, 'complete')",
+        ("batch-one",),
+    )
+    conn.commit()
+    conn.close()
+
+    command.upgrade(cfg, "head")
+
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    columns = [row[1] for row in cur.execute("PRAGMA table_info(overnight_batches)")]
+    assert "deleted_at" in columns
+    cur.execute(
+        "UPDATE overnight_batches SET deleted_at='2024-01-01T00:00:00' WHERE id=?",
+        ("batch-one",),
+    )
+    conn.commit()
+    cur.execute("SELECT deleted_at FROM overnight_batches WHERE id=?", ("batch-one",))
+    assert cur.fetchone()[0] == "2024-01-01T00:00:00"
+    conn.close()


### PR DESCRIPTION
## Summary
- add a deleted_at column to overnight batches and extend the API with filtering plus per-batch and bulk soft-delete endpoints
- update the overnight runner and UI to ignore soft-deleted work and expose Show finished / clear controls in the queue
- add regression coverage for the new soft-delete flows and migration

## Testing
- pytest tests/test_overnight.py tests/test_migration_0004.py tests/test_migration_0005.py

------
https://chatgpt.com/codex/tasks/task_e_68c848b4fe588329adf14d85b57989c1