### PR TITLE
Harden favorites lookback migration

### DIFF
--- a/alembic/versions/0004_favorites_lookback_backfill.py
+++ b/alembic/versions/0004_favorites_lookback_backfill.py
@@ -1,4 +1,4 @@
-"""Backfill favorites lookback values
+"""Backfill favorites lookback values.
 
 Revision ID: 0004
 Revises: 0003
@@ -6,10 +6,49 @@ Create Date: 2024-09-01 00:00:00.000000
 """
 from __future__ import annotations
 
+import logging
+import sqlite3
+
 try:  # pragma: no cover - prefer real Alembic if available
     from alembic import op  # type: ignore
 except Exception:  # pragma: no cover - fallback stub
     from alembic_stub import op
+
+try:  # pragma: no cover - prefer SQLAlchemy if available
+    from sqlalchemy.exc import OperationalError as SAOperationalError  # type: ignore
+except Exception:  # pragma: no cover - fallback when SQLAlchemy missing
+    SAOperationalError = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+_operation_errors: list[type[BaseException]] = []
+if SAOperationalError is not None:
+    _operation_errors.append(SAOperationalError)
+if hasattr(sqlite3, "OperationalError"):
+    _operation_errors.append(sqlite3.OperationalError)
+OPERATIONAL_ERRORS: tuple[type[BaseException], ...] = tuple(_operation_errors)
+
+
+def _is_operational_error(exc: BaseException) -> bool:
+    if not OPERATIONAL_ERRORS:
+        return False
+    return isinstance(exc, OPERATIONAL_ERRORS)
+
+
+def _safe_execute(sql: str, context: str) -> None:
+    try:
+        op.execute(sql)
+    except Exception as exc:  # pragma: no cover - best effort logging only
+        if _is_operational_error(exc):
+            logger.warning(
+                "Migration 0004 skipped %s due to operational error: %s",
+                context,
+                exc,
+            )
+            return
+        logger.exception("Migration 0004 failed while executing %s", context)
+        raise
 
 
 revision = "0004"
@@ -20,18 +59,66 @@ depends_on = None
 
 def upgrade() -> None:
     conn = op.get_bind()
-    cols = [row[1] for row in conn.exec_driver_sql("PRAGMA table_info(favorites)").fetchall()]
+    cols = {
+        row[1]
+        for row in conn.exec_driver_sql("PRAGMA table_info(favorites)").fetchall()
+    }
+
     if "lookback_years" not in cols:
+        logger.info("Adding favorites.lookback_years column during migration 0004")
         op.execute("ALTER TABLE favorites ADD COLUMN lookback_years REAL")
 
-    op.execute(
+    support_exists = "support_snapshot" in cols
+    params_exists = "params_json" in cols
+
+    if not support_exists:
+        try:
+            op.execute("ALTER TABLE favorites ADD COLUMN support_snapshot TEXT")
+            logger.info(
+                "Added missing favorites.support_snapshot column during migration 0004"
+            )
+            support_exists = True
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning(
+                "favorites.support_snapshot column missing; skipping JSON backfill: %s",
+                exc,
+            )
+
+    if support_exists:
+        _safe_execute(
+            """
+            UPDATE favorites
+               SET lookback_years = CAST(json_extract(support_snapshot, '$.lookback_years') AS REAL)
+             WHERE (lookback_years IS NULL OR lookback_years IN (0, 0.2))
+               AND json_type(json_extract(support_snapshot, '$.lookback_years')) IN ('integer','real');
+            """,
+            "support_snapshot lookback backfill",
+        )
+    else:
+        logger.warning(
+            "Skipping favorites.support_snapshot backfill; column is not available"
+        )
+
+    if params_exists:
+        fallback_sql = """
+            UPDATE favorites
+               SET lookback_years = CAST(json_extract(params_json, '$.lookback_years') AS REAL)
+             WHERE (lookback_years IS NULL OR lookback_years IN (0, 0.2))
+               AND json_type(json_extract(params_json, '$.lookback_years')) IN ('integer','real')
         """
-        UPDATE favorites
-           SET lookback_years = CAST(json_extract(support_snapshot, '$.lookback_years') AS REAL)
-         WHERE (lookback_years IS NULL OR lookback_years IN (0, 0.2))
-           AND json_type(json_extract(support_snapshot, '$.lookback_years')) IN ('integer','real');
-        """
-    )
+        if support_exists:
+            fallback_sql += """
+               AND (
+                    support_snapshot IS NULL
+                    OR TRIM(COALESCE(CAST(support_snapshot AS TEXT), '')) = ''
+                    OR COALESCE(
+                        json_type(json_extract(support_snapshot, '$.lookback_years')),
+                        ''
+                    ) NOT IN ('integer','real')
+               )
+            """
+        fallback_sql += ";"
+        _safe_execute(fallback_sql, "params_json lookback fallback")
 
 
 def downgrade() -> None:

--- a/db.py
+++ b/db.py
@@ -126,7 +126,7 @@ SCHEMA = [
         roi_snapshot REAL,
         hit_pct_snapshot REAL,
         dd_pct_snapshot REAL,
-        support_snapshot INTEGER,
+        support_snapshot TEXT,
         rule_snapshot TEXT,
         settings_json_snapshot TEXT,
         snapshot_at TEXT,

--- a/tests/test_favorites.py
+++ b/tests/test_favorites.py
@@ -100,10 +100,11 @@ def test_add_favorite_persists_lookback(tmp_path):
     assert lookback == 2.0
     assert min_support == 35
 
+    assert support_snapshot is not None
     support_data = json.loads(support_snapshot)
-    assert support_data["count"] == 40
-    assert support_data["lookback_years"] == 2.0
-    assert support_data["min_support"] == 35
+    assert support_data.get("count") == 40
+    assert support_data.get("lookback_years") == 2.0
+    assert support_data.get("min_support") == 35
 
     settings_data = json.loads(settings_snapshot)
     assert settings_data["lookback_years"] == "2.0"

--- a/tests/test_favorites_page.py
+++ b/tests/test_favorites_page.py
@@ -1,3 +1,4 @@
+import json
 import sqlite3
 
 from fastapi import FastAPI
@@ -14,7 +15,8 @@ def _setup_app(tmp_path):
     conn = sqlite3.connect(db.DB_PATH)
     cur = conn.cursor()
     cur.execute(
-        "INSERT INTO favorites(ticker,direction,interval,rule,lookback_years,min_support,support_snapshot) VALUES('AAA','UP','15m','r',1.5,30,45)"
+        "INSERT INTO favorites(ticker,direction,interval,rule,lookback_years,min_support,support_snapshot) VALUES('AAA','UP','15m','r',1.5,30,?)",
+        (json.dumps({"count": 45, "lookback_years": 1.5}),),
     )
     conn.commit()
     app = FastAPI()

--- a/tests/test_migration_0004.py
+++ b/tests/test_migration_0004.py
@@ -4,8 +4,12 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
 
 import db
+import routes
 
 
 def _alembic_config(db_path: Path) -> Config:
@@ -43,4 +47,130 @@ def test_migration_0004_backfills_lookback(tmp_path):
     conn.close()
 
     assert lookback == 2.5
+
+
+def test_migration_0004_handles_missing_support_snapshot(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    db.DB_PATH = str(db_path)
+
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE favorites (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ticker TEXT NOT NULL,
+            direction TEXT NOT NULL,
+            interval TEXT NOT NULL,
+            rule TEXT NOT NULL,
+            lookback_years REAL,
+            min_support INTEGER,
+            params_json TEXT,
+            roi_snapshot REAL,
+            hit_pct_snapshot REAL,
+            dd_pct_snapshot REAL,
+            rule_snapshot TEXT,
+            settings_json_snapshot TEXT,
+            snapshot_at TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        INSERT INTO favorites(
+            ticker, direction, interval, rule, lookback_years, min_support, params_json
+        )
+        VALUES(?,?,?,?,?,?,?)
+        """,
+        (
+            "BBB",
+            "DOWN",
+            "15m",
+            "r2",
+            0.0,
+            25,
+            json.dumps({"lookback_years": 3.5}),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    cfg = _alembic_config(db_path)
+    command.upgrade(cfg, "head")
+
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(favorites)")
+    cols = {row[1] for row in cur.fetchall()}
+    assert "support_snapshot" in cols
+
+    cur.execute(
+        "SELECT lookback_years, support_snapshot FROM favorites WHERE ticker='BBB'"
+    )
+    lookback, snapshot = cur.fetchone()
+    conn.close()
+
+    assert lookback == 3.5
+    assert snapshot is None
+
+
+def test_migration_0004_smoke_app_without_snapshot(tmp_path):
+    db_path = tmp_path / "legacy_app.db"
+    db.DB_PATH = str(db_path)
+
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE favorites (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ticker TEXT NOT NULL,
+            direction TEXT NOT NULL,
+            interval TEXT NOT NULL,
+            rule TEXT NOT NULL,
+            lookback_years REAL,
+            min_support INTEGER,
+            params_json TEXT,
+            roi_snapshot REAL,
+            hit_pct_snapshot REAL,
+            dd_pct_snapshot REAL,
+            rule_snapshot TEXT,
+            settings_json_snapshot TEXT,
+            snapshot_at TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        INSERT INTO favorites(
+            ticker, direction, interval, rule, lookback_years, min_support, params_json
+        )
+        VALUES(?,?,?,?,?,?,?)
+        """,
+        (
+            "AAA",
+            "UP",
+            "15m",
+            "r1",
+            0.0,
+            30,
+            json.dumps({"lookback_years": 4.0}),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    cfg = _alembic_config(db_path)
+    command.upgrade(cfg, "head")
+
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.mount("/static", StaticFiles(directory="static"), name="static")
+    client = TestClient(app)
+
+    res = client.get("/favorites")
+    assert res.status_code == 200
+    body = res.text
+    assert "Favorites" in body
+    assert "4y" in body
 


### PR DESCRIPTION
## Summary
- make migration 0004 resilient to missing favorites.support_snapshot, adding the column when necessary and falling back to params_json lookbacks with guarded logging
- ensure new databases create favorites.support_snapshot as TEXT and update favorites tests to tolerate absent keys and use JSON snapshots
- add migration regression tests covering legacy schemas and a smoke test that renders the favorites page after upgrading

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c85a612bc8832980d362d54524c423