### PR TITLE
Enable MMS favorites formatter for test alerts

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -108,7 +108,7 @@
           <label>Channel</label>
           <select id="fav-test-channel">
             <option value="email" {% if smtp_configured %}selected{% endif %}>Email</option>
-            <option value="mms" {% if not smtp_configured %}selected{% endif %} {% if not twilio_configured %}disabled title="MMS requires Twilio configuration"{% endif %}>MMS</option>
+            <option value="mms" {% if not smtp_configured %}selected{% endif %}>MMS</option>
           </select>
         </div>
         <div>

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,6 +1,6 @@
 from datetime import date, timedelta
 
-from services.favorites_alerts import FavoriteHitStub, format_mms, Check
+from services.favorites_alerts import format_favorites_alert, Check
 from services.options_provider import OptionContract
 
 
@@ -27,19 +27,68 @@ def sample_contract():
     )
 
 
-def test_formatter_verbose_vs_compact():
-    hit = FavoriteHitStub(ticker="AAPL", direction="UP", pattern="Test")
+def test_formatter_mms_verbose_vs_compact():
+    contract = sample_contract()
+    checks = [
+        Check("Delta", "Δ", 0.5, True, "balanced delta."),
+        Check(
+            "Open Interest",
+            "OI",
+            100,
+            False,
+            "Open interest too low — Not enough contracts.",
+        ),
+    ]
+    targets = {"target": 185.0, "stop": 194.0, "hit": 70, "roi": 12, "dd": 8}
+    body_verbose = format_favorites_alert(
+        "AAPL",
+        "UP",
+        contract,
+        checks,
+        targets,
+        compact=False,
+        channel="mms",
+        pattern="Test",
+    )
+    assert "Greeks & IV:" in body_verbose
+    assert "• Delta (0.5)" in body_verbose
+    assert "balanced delta" in body_verbose
+    assert "Open interest too low" in body_verbose
+    assert "Targets: 185" in body_verbose
+
+    body_compact = format_favorites_alert(
+        "AAPL",
+        "UP",
+        contract,
+        checks,
+        targets,
+        compact=True,
+        channel="mms",
+        pattern="Test",
+    )
+    assert "• Delta" not in body_compact
+    assert "Open interest too low" in body_compact
+    assert "Feedback:" in body_compact
+    assert "Open interest too low" in body_compact
+
+
+def test_formatter_email_keeps_summary():
     contract = sample_contract()
     checks = [
         Check("Delta", "Δ", 0.5, True),
         Check("Open Interest", "OI", 100, False, "Open interest too low"),
     ]
-    profile_verbose = {"compact_mms": False, "include_symbols_in_alerts": True}
-    body_verbose = format_mms(hit, contract, checks, profile_verbose)
-    assert "Δ" in body_verbose and "OI" in body_verbose
-    assert "Open interest too low" in body_verbose
-
-    profile_compact = {"compact_mms": True, "include_symbols_in_alerts": True}
-    body_compact = format_mms(hit, contract, checks, profile_compact)
-    assert "Delta" not in body_compact  # passed check removed
-    assert "OI" in body_compact and "Open interest too low" in body_compact
+    body_email = format_favorites_alert(
+        "AAPL",
+        "UP",
+        contract,
+        checks,
+        {"target": None},
+        compact=False,
+        channel="email",
+        pattern="Test",
+    )
+    assert "AAPL UP Test" in body_email
+    assert "Contract AAPL" in body_email
+    assert "Delta (Δ):" in body_email
+    assert "Why this contract" in body_email


### PR DESCRIPTION
## Summary
- allow the favorites settings UI to always expose the MMS channel option
- add a shared favorites alert formatter that outputs the rich MMS layout and keep email output intact
- reuse the formatter for the test alert endpoint and extend unit/API tests for verbose and compact previews

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8630aebac8329871c3933af833b93