### PR TITLE
Improve intraday gap fill scheduling

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,8 +10,8 @@ def _bool(name: str, default: str = "false") -> bool:
 class Settings:
     run_migrations: bool = _bool("RUN_MIGRATIONS", "true")
     database_url: str = os.getenv("DATABASE_URL", "sqlite:///patternfinder.db")
-    http_max_concurrency: int = int(os.getenv("HTTP_MAX_CONCURRENCY", "10"))
-    job_timeout: int = int(os.getenv("JOB_TIMEOUT", "30"))
+    http_max_concurrency: int = int(os.getenv("HTTP_MAX_CONCURRENCY", "1"))
+    job_timeout: int = int(os.getenv("JOB_TIMEOUT", "60"))
     metrics_enabled: bool = _bool("METRICS_ENABLED", "false")
     clamp_market_closed: bool = _bool("CLAMP_MARKET_CLOSED", "true")
     backfill_chunk_days: int = int(os.getenv("BACKFILL_CHUNK_DAYS", "1"))
@@ -29,6 +29,7 @@ class Settings:
     scan_fetch_concurrency: int = int(os.getenv("SCAN_FETCH_CONCURRENCY", "8"))
     scan_coverage_batch_size: int = int(os.getenv("SCAN_COVERAGE_BATCH_SIZE", "200"))
     scan_symbols_per_task: int = int(os.getenv("SCAN_SYMBOLS_PER_TASK", "1"))
+    scan_minimal_near_now: bool = _bool("SCAN_MINIMAL_NEAR_NOW", "1")
 
 
 settings = Settings()

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,11 +1,12 @@
 # ruff: noqa: E501
 import asyncio
+import json
 import logging
 import os
 import random
 import sqlite3
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, Callable, Dict
 
 from config import settings
@@ -13,16 +14,23 @@ from db import DB_PATH, get_settings, row_to_dict, set_last_run
 from prometheus_client import Counter  # type: ignore
 from routes import _update_forward_tests  # type: ignore
 from scanner import preload_prices  # type: ignore
-from services.polygon_client import fetch_polygon_prices_async
+from services.http_client import RateLimitTimeoutSoon
+from services.polygon_client import compute_request_window, fetch_polygon_prices_async
 from services.price_store import covers, get_coverage, missing_ranges, upsert_bars
 from services import favorites_alerts
-from utils import clamp_market_closed
+from utils import clamp_market_closed, market_is_open as util_market_is_open
 
 logger = logging.getLogger(__name__)
 
 job_queued = Counter("scheduler_jobs_queued_total", "Jobs queued")
 job_success = Counter("scheduler_jobs_success_total", "Jobs succeeded")
 job_failure = Counter("scheduler_jobs_failure_total", "Jobs failed")
+
+RETRY_SHIFT = timedelta(minutes=15)
+FAIL_FAST_NETWORK_BUFFER = float(os.getenv("SCAN_FAIL_FAST_NETWORK_BUFFER", "1.5"))
+FAIL_FAST_SAFETY_MARGIN = float(os.getenv("SCAN_FAIL_FAST_SAFETY_MARGIN", "0.25"))
+REQUEUE_MIN_DELAY = float(os.getenv("SCAN_FAIL_FAST_REQUEUE_MIN", "0.75"))
+REQUEUE_MAX_DELAY = float(os.getenv("SCAN_FAIL_FAST_REQUEUE_MAX", "2.0"))
 
 
 class WorkQueue:
@@ -70,6 +78,7 @@ def queue_gap_fill(symbol: str, start, end, interval: str) -> None:
         start_time = time.monotonic()
         rows_total = 0
         deadline = start_time + float(os.getenv("SCAN_SOFT_DEADLINE", "120"))
+        job_deadline = start_time + float(settings.job_timeout)
         if settings.clamp_market_closed:
             new_end, clamped = clamp_market_closed(start, end)
             if clamped:
@@ -103,45 +112,191 @@ def queue_gap_fill(symbol: str, start, end, interval: str) -> None:
             to_fetch,
         )
         chunk = timedelta(days=settings.backfill_chunk_days)
+        last_bar = cov_max
         for a, b in to_fetch:
             cur = a
             while cur < b:
-                if time.monotonic() > deadline:
+                now_mono = time.monotonic()
+                if now_mono > deadline:
                     logger.info("fetch_deadline symbol=%s", symbol)
                     break
+                if now_mono >= job_deadline:
+                    logger.info("gap_job_timeout symbol=%s interval=%s", symbol, interval)
+                    return
                 nxt = min(cur + chunk, b)
-                logger.info(
-                    "fetch_call symbol=%s requested_start=%s requested_end=%s",
-                    symbol,
-                    cur.isoformat(),
-                    nxt.isoformat(),
-                )
-                try:
-                    df_map = await fetch_polygon_prices_async(
-                        [symbol], interval, cur, nxt
+                request_start = cur
+                request_end = nxt
+                now_utc = datetime.now(timezone.utc)
+                mode = "range"
+                if interval == "15m":
+                    request_start, request_end, mode = compute_request_window(
+                        symbol,
+                        interval,
+                        request_start,
+                        request_end,
+                        last_bar=last_bar,
+                        now=now_utc,
                     )
-                    df_p = df_map.get(symbol)
-                    if df_p is not None and not df_p.empty:
-                        rows_total += len(df_p)
-                        upsert_bars(symbol, df_p, interval)
+                logger.info(
+                    json.dumps(
+                        {
+                            "type": "gap_slice",
+                            "symbol": symbol,
+                            "interval": interval,
+                            "mode": mode,
+                            "start": request_start.isoformat(),
+                            "end": request_end.isoformat(),
+                        }
+                    )
+                )
+
+                attempt = 1
+                retry_done = False
+                window_start = request_start
+                window_end = request_end
+
+                while True:
+                    remaining_job = job_deadline - time.monotonic()
+                    if remaining_job <= 0:
                         logger.info(
-                            "fetch_ok symbol=%s rows=%d",
+                            json.dumps(
+                                {
+                                    "type": "gap_fail_fast",
+                                    "symbol": symbol,
+                                    "interval": interval,
+                                    "predicted_wait_s": 0.0,
+                                    "remaining_s": 0.0,
+                                    "reason": "deadline_elapsed",
+                                }
+                            )
+                        )
+                        return
+
+                    rate_state: Dict[str, float] = {}
+                    timeout_ctx = {
+                        "deadline": job_deadline,
+                        "remaining": max(0.0, remaining_job),
+                        "network_buffer": FAIL_FAST_NETWORK_BUFFER,
+                        "safety_margin": FAIL_FAST_SAFETY_MARGIN,
+                        "rate_state": rate_state,
+                    }
+
+                    call_start = time.monotonic()
+                    try:
+                        df_map = await fetch_polygon_prices_async(
+                            [symbol],
+                            interval,
+                            window_start,
+                            window_end,
+                            timeout_ctx=timeout_ctx,
+                        )
+                    except RateLimitTimeoutSoon as rl:
+                        log_data = {
+                            "type": "gap_fail_fast",
+                            "symbol": symbol,
+                            "interval": interval,
+                            "predicted_wait_s": rl.predicted_wait,
+                            "remaining_s": rl.remaining,
+                        }
+                        logger.info(json.dumps(log_data))
+
+                        delay = random.uniform(REQUEUE_MIN_DELAY, REQUEUE_MAX_DELAY)
+
+                        async def _requeue() -> None:
+                            await asyncio.sleep(delay)
+                            queue_gap_fill(symbol, start, end_local, interval)
+
+                        asyncio.create_task(_requeue())
+                        return
+                    except Exception as e:
+                        import traceback as _tb
+
+                        logger.error(
+                            "fetch_error symbol=%s err=%s msg=%s\n%s",
                             symbol,
-                            len(df_p),
+                            type(e).__name__,
+                            e,
+                            _tb.format_exc(),
+                        )
+                        break
+
+                    df_p = df_map.get(symbol)
+                    rows = len(df_p) if df_p is not None and not df_p.empty else 0
+                    duration_ms = int((time.monotonic() - call_start) * 1000)
+                    rate_wait_ms = int(rate_state.get("waited", 0.0) * 1000)
+
+                    logger.info(
+                        json.dumps(
+                            {
+                                "type": "gap_request_done",
+                                "symbol": symbol,
+                                "interval": interval,
+                                "mode": mode,
+                                "attempt": attempt,
+                                "start": window_start.isoformat(),
+                                "end": window_end.isoformat(),
+                                "rows": rows,
+                                "duration_ms": duration_ms,
+                                "rate_wait_ms": rate_wait_ms,
+                            }
+                        )
+                    )
+
+                    if rows > 0 and df_p is not None:
+                        rows_total += rows
+                        upsert_bars(symbol, df_p, interval)
+                        try:
+                            last_bar = df_p.index.max().to_pydatetime()
+                        except Exception:
+                            pass
+                        logger.info("fetch_ok symbol=%s rows=%d", symbol, rows)
+                        break
+
+                    if (
+                        mode == "single_bucket"
+                        and not retry_done
+                        and util_market_is_open(now_utc)
+                    ):
+                        retry_done = True
+                        prev_start = window_start
+                        prev_end = window_end
+                        window_start = prev_start - RETRY_SHIFT
+                        logger.info(
+                            json.dumps(
+                                {
+                                    "type": "gap_retry_smaller_slice",
+                                    "symbol": symbol,
+                                    "interval": interval,
+                                    "prev_start": prev_start.isoformat(),
+                                    "prev_end": prev_end.isoformat(),
+                                    "next_start": window_start.isoformat(),
+                                    "next_end": window_end.isoformat(),
+                                }
+                            )
+                        )
+                        attempt += 1
+                        continue
+
+                    if mode == "single_bucket":
+                        logger.info(
+                            json.dumps(
+                                {
+                                    "type": "gap_empty_near_now",
+                                    "symbol": symbol,
+                                    "interval": interval,
+                                    "start": window_start.isoformat(),
+                                    "end": window_end.isoformat(),
+                                }
+                            )
                         )
                     else:
                         logger.info("fetch_empty symbol=%s", symbol)
-                except Exception as e:
-                    import traceback as _tb
+                    break
 
-                    logger.error(
-                        "fetch_error symbol=%s err=%s msg=%s\n%s",
-                        symbol,
-                        type(e).__name__,
-                        e,
-                        _tb.format_exc(),
-                    )
-                cur = nxt
+                if mode == "single_bucket":
+                    cur = b
+                else:
+                    cur = request_end
 
         duration = time.monotonic() - start_time
         logger.info(

--- a/tests/test_backfill_multi_symbol.py
+++ b/tests/test_backfill_multi_symbol.py
@@ -25,7 +25,7 @@ def test_backfill_two_symbols(monkeypatch, caplog):
         index=pd.date_range("2024-01-01", periods=1, freq="15T", tz="UTC"),
     )
 
-    async def fake_fetch(symbols, interval, start, end):
+    async def fake_fetch(symbols, interval, start, end, **kwargs):
         sym = symbols[0]
         logger = logging.getLogger("services.polygon_client")
         logger.info("polygon_fetch symbol=%s pages=1 rows=1 duration=0.00", sym)

--- a/tests/test_backfill_resume.py
+++ b/tests/test_backfill_resume.py
@@ -20,7 +20,7 @@ def test_backfill_resume(monkeypatch, tmp_path):
     monkeypatch.setattr(backfill, "CHECKPOINT", chk)
 
     # stub polygon fetch
-    async def fake_fetch(symbols, interval, start, end):
+    async def fake_fetch(symbols, interval, start, end, **kwargs):
         return {symbols[0]: pd.DataFrame()}
 
     monkeypatch.setattr(polygon_client, "fetch_polygon_prices_async", fake_fetch)

--- a/tests/test_backfill_test_mode.py
+++ b/tests/test_backfill_test_mode.py
@@ -25,7 +25,7 @@ def test_quick_test_mode(monkeypatch, caplog):
         index=pd.date_range("2024-01-01", periods=2, freq="15T", tz="UTC"),
     )
 
-    async def fake_fetch(symbols, interval, start, end):
+    async def fake_fetch(symbols, interval, start, end, **kwargs):
         assert symbols == ["SPY"]
         assert interval == "15m"
         assert end - start <= dt.timedelta(days=1, minutes=1)

--- a/tests/test_gap_scheduler_fetcher.py
+++ b/tests/test_gap_scheduler_fetcher.py
@@ -16,7 +16,7 @@ async def run_job(monkeypatch, tmp_path, df_return, capture=None):
     end = pd.Timestamp("2024-01-01 20:00", tz="UTC").to_pydatetime()
     monkeypatch.setattr(scheduler.settings, "clamp_market_closed", False)
 
-    async def fake_fetch(symbols, interval, s, e):
+    async def fake_fetch(symbols, interval, s, e, **kwargs):
         if capture is not None:
             capture["start"] = s
             capture["end"] = e

--- a/tests/test_gapfill_15m.py
+++ b/tests/test_gapfill_15m.py
@@ -1,0 +1,192 @@
+import asyncio
+import importlib
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+import pytest
+
+import config
+import scheduler
+from services.http_client import RateLimitTimeoutSoon
+from services import polygon_client
+
+
+def _reset_work_queue() -> None:
+    try:
+        scheduler.work_queue.queue.task_done()
+    except ValueError:
+        pass
+    scheduler.work_queue.keys.clear()
+
+
+def test_single_bucket_request_window(monkeypatch):
+    monkeypatch.setattr(polygon_client.settings, "scan_minimal_near_now", True)
+    last_bar = datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc)
+    now = datetime(2024, 1, 2, 14, 40, tzinfo=timezone.utc)
+    default_start = last_bar
+    default_end = last_bar + timedelta(days=1)
+
+    start, end, mode = polygon_client.compute_request_window(
+        "AAA",
+        "15m",
+        default_start,
+        default_end,
+        last_bar=last_bar,
+        now=now,
+    )
+
+    assert mode == "single_bucket"
+    assert start == last_bar
+    assert end == last_bar + timedelta(minutes=15)
+
+
+def test_fail_fast_requeues_gap_job(monkeypatch):
+    symbol = "AAA"
+    start = datetime(2024, 1, 3, 14, 0, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=30)
+
+    monkeypatch.setattr(scheduler.settings, "clamp_market_closed", False)
+    monkeypatch.setattr(scheduler, "covers", lambda *args, **kwargs: False)
+    monkeypatch.setattr(
+        scheduler,
+        "get_coverage",
+        lambda *args, **kwargs: (start - timedelta(minutes=15), start),
+    )
+    monkeypatch.setattr(scheduler, "missing_ranges", lambda *args, **kwargs: [(start, end)])
+    monkeypatch.setattr(
+        scheduler,
+        "upsert_bars",
+        lambda *args, **kwargs: pytest.fail("upsert should not be called"),
+    )
+
+    async def fail_fetch(symbols, interval, s, e, timeout_ctx=None):
+        raise RateLimitTimeoutSoon("api.polygon.io", 12.0, 10.0)
+
+    monkeypatch.setattr(scheduler, "fetch_polygon_prices_async", fail_fetch)
+    monkeypatch.setattr(scheduler.random, "uniform", lambda a, b: 0.0)
+
+    async def fast_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(scheduler.asyncio, "sleep", fast_sleep)
+
+    scheduler.queue_gap_fill(symbol, start, end, "15m")
+    _key, job = scheduler.work_queue.queue.get_nowait()
+
+    requeues: list[tuple[str, datetime, datetime, str]] = []
+
+    def capture_queue(sym, s, e, interval):
+        requeues.append((sym, s, e, interval))
+
+    monkeypatch.setattr(scheduler, "queue_gap_fill", capture_queue)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(job())
+        loop.run_until_complete(asyncio.sleep(0))
+    finally:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
+        asyncio.set_event_loop(None)
+        _reset_work_queue()
+
+    assert requeues == [(symbol, start, end, "15m")]
+
+
+def test_retry_smaller_slice(monkeypatch):
+    symbol = "BBB"
+    start = datetime(2024, 1, 4, 14, 0, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=30)
+
+    monkeypatch.setattr(scheduler.settings, "clamp_market_closed", False)
+    monkeypatch.setattr(scheduler, "covers", lambda *args, **kwargs: False)
+    monkeypatch.setattr(
+        scheduler,
+        "get_coverage",
+        lambda *args, **kwargs: (start - timedelta(minutes=15), start),
+    )
+    monkeypatch.setattr(scheduler, "missing_ranges", lambda *args, **kwargs: [(start, end)])
+    monkeypatch.setattr(scheduler, "util_market_is_open", lambda *_: True)
+    monkeypatch.setattr(
+        scheduler,
+        "upsert_bars",
+        lambda *args, **kwargs: pytest.fail("unexpected write"),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "compute_request_window",
+        lambda *args, **kwargs: (start, start + timedelta(minutes=15), "single_bucket"),
+    )
+
+    calls: list[tuple[datetime, datetime]] = []
+
+    async def empty_fetch(symbols, interval, s, e, timeout_ctx=None):
+        calls.append((s, e))
+        return {symbols[0]: pd.DataFrame()}
+
+    monkeypatch.setattr(scheduler, "fetch_polygon_prices_async", empty_fetch)
+
+    scheduler.queue_gap_fill(symbol, start, end, "15m")
+    _key, job = scheduler.work_queue.queue.get_nowait()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(job())
+    finally:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
+        asyncio.set_event_loop(None)
+        _reset_work_queue()
+
+    assert len(calls) == 2
+    first_start, first_end = calls[0]
+    second_start, second_end = calls[1]
+    assert second_start == first_start - timedelta(minutes=15)
+    assert second_end == first_end
+
+
+def test_default_env_settings(monkeypatch):
+    env_keys = [
+        "SCAN_RPS",
+        "POLY_RPS",
+        "SCAN_MAX_CONCURRENCY",
+        "POLY_BURST",
+        "HTTP_MAX_CONCURRENCY",
+        "JOB_TIMEOUT",
+    ]
+    for key in env_keys:
+        monkeypatch.delenv(key, raising=False)
+
+    importlib.reload(config)
+    importlib.reload(polygon_client)
+
+    assert config.settings.http_max_concurrency == 1
+    assert config.settings.job_timeout == 60
+    assert polygon_client.POLY_RPS == 1.0
+    assert polygon_client.POLY_BURST == 2
+
+    monkeypatch.setenv("POLY_RPS", "0.5")
+    monkeypatch.setenv("POLY_BURST", "7")
+    monkeypatch.setenv("HTTP_MAX_CONCURRENCY", "5")
+    monkeypatch.setenv("JOB_TIMEOUT", "90")
+
+    importlib.reload(config)
+    importlib.reload(polygon_client)
+
+    assert config.settings.http_max_concurrency == 5
+    assert config.settings.job_timeout == 90
+    assert polygon_client.POLY_RPS == 0.5
+    assert polygon_client.POLY_BURST == 7
+
+    for key in ["POLY_RPS", "POLY_BURST", "HTTP_MAX_CONCURRENCY", "JOB_TIMEOUT"]:
+        monkeypatch.delenv(key, raising=False)
+
+    importlib.reload(config)
+    importlib.reload(polygon_client)
+
+    assert config.settings.http_max_concurrency == 1
+    assert config.settings.job_timeout == 60
+    assert polygon_client.POLY_RPS == 1.0
+    assert polygon_client.POLY_BURST == 2


### PR DESCRIPTION
## Summary
- add compute_request_window helper and telemetry to support single-bucket intraday gap requests with optional retries
- introduce fail-fast handling for polygon rate limiting and tighten defaults for intraday scans
- add regression tests covering single-bucket slices, fail-fast behaviour, retry logic, and updated defaults

## Testing
- pytest tests/test_gapfill_15m.py tests/test_gap_scheduler_fetcher.py
- pytest tests/test_rate_limit.py tests/test_http_client_backoff.py tests/test_polygon_rate_limit_env.py

------
https://chatgpt.com/codex/tasks/task_e_68c894eee0108329a3c531ef25642c48