### PR TITLE
Validate overnight universes and improve logging

### DIFF
--- a/templates/overnight.html
+++ b/templates/overnight.html
@@ -28,6 +28,7 @@
       {% include '_scanner_form.html' %}
     </form>
     <button class="rm">🗑</button>
+    <div class="ov-error" role="alert" aria-live="polite"></div>
   </div>
 </template>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a reusable universe resolution helper so overnight scan logs include universe, ticker, and symbol totals and so empty universes return explicit errors
- expose an /overnight/validate endpoint and block start_now when queued items resolve to zero symbols
- add UI validation with inline feedback and safe defaults before saving or starting overnight batches

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8d8111d648329875a0a6fc86bf13c