### PR TITLE
Ensure forward test exit columns exist

### DIFF
--- a/alembic/versions/0006_forward_test_exit_columns.py
+++ b/alembic/versions/0006_forward_test_exit_columns.py
@@ -1,0 +1,50 @@
+"""Add forward test exit metadata columns
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2024-09-16 00:00:00.000000
+"""
+from __future__ import annotations
+
+try:
+    from alembic import op  # type: ignore
+except Exception:  # pragma: no cover - fallback stub
+    from alembic_stub import op
+
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+_COLUMNS_TO_ADD = {
+    "exit_reason": "TEXT",
+    "bars_to_exit": "INTEGER",
+    "max_drawdown_pct": "REAL",
+    "max_runup_pct": "REAL",
+    "r_multiple": "REAL",
+    "option_roi_proxy": "REAL",
+}
+
+
+def _existing_forward_columns() -> set[str]:
+    get_bind = getattr(op, "get_bind", None)
+    if callable(get_bind):
+        conn = get_bind()
+        try:
+            result = conn.exec_driver_sql("PRAGMA table_info('forward_tests')")
+        except AttributeError:
+            result = conn.execute("PRAGMA table_info('forward_tests')")
+    else:
+        result = op.execute("PRAGMA table_info('forward_tests')")
+    return {row[1] for row in result.fetchall()}
+
+
+def upgrade() -> None:
+    existing = _existing_forward_columns()
+    for name, column_type in _COLUMNS_TO_ADD.items():
+        if name not in existing:
+            op.execute(f"ALTER TABLE forward_tests ADD COLUMN {name} {column_type}")
+
+
+def downgrade() -> None:
+    raise RuntimeError("downgrade not supported")

--- a/alembic_stub/__init__.py
+++ b/alembic_stub/__init__.py
@@ -6,8 +6,11 @@ class _Op:
     def __init__(self, conn):
         self.conn = conn
 
-    def execute(self, sql: str) -> None:
-        self.conn.execute(sql)
+    def execute(self, sql: str):
+        return self.conn.execute(sql)
+
+    def get_bind(self):
+        return self.conn
 
 
 def set_connection(conn) -> None:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -26,3 +26,66 @@ def test_forward_tests_table_exists(tmp_path):
     cols = {r[1] for r in cur.fetchall()}
     conn.close()
     assert {"status", "roi_1", "roi_expiry", "option_roi_proxy"}.issubset(cols)
+
+
+def test_forward_tests_migration_adds_exit_columns(tmp_path):
+    db.DB_PATH = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db.DB_PATH)
+    conn.executescript(
+        """
+        CREATE TABLE forward_tests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            fav_id INTEGER NOT NULL,
+            ticker TEXT NOT NULL,
+            direction TEXT NOT NULL,
+            interval TEXT NOT NULL,
+            rule TEXT,
+            version INTEGER NOT NULL DEFAULT 1,
+            entry_price REAL NOT NULL,
+            target_pct REAL NOT NULL,
+            stop_pct REAL NOT NULL,
+            window_minutes INTEGER NOT NULL,
+            status TEXT NOT NULL DEFAULT 'queued',
+            roi_forward REAL,
+            hit_forward REAL,
+            dd_forward REAL,
+            roi_1 REAL,
+            roi_3 REAL,
+            roi_5 REAL,
+            roi_expiry REAL,
+            mae REAL,
+            mfe REAL,
+            time_to_hit REAL,
+            time_to_stop REAL,
+            option_expiry TEXT,
+            option_strike REAL,
+            option_delta REAL,
+            last_run_at TEXT,
+            next_run_at TEXT,
+            runs_count INTEGER NOT NULL DEFAULT 0,
+            notes TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    db.init_db()
+
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(forward_tests)")
+    columns = {row[1] for row in cur.fetchall()}
+    conn.close()
+
+    expected = {
+        "exit_reason",
+        "bars_to_exit",
+        "max_drawdown_pct",
+        "max_runup_pct",
+        "r_multiple",
+        "option_roi_proxy",
+    }
+    assert expected.issubset(columns)


### PR DESCRIPTION
## Summary
- add an Alembic migration that backfills the forward test exit metadata columns when they are missing
- update the Alembic stub helper so migrations can query the current schema
- add a regression test to confirm the new migration creates the expected columns

## Testing
- pytest tests/test_db.py tests/test_forward.py

------
https://chatgpt.com/codex/tasks/task_e_68c99cd5b394832990ec56e78a8e5dd5