### PR TITLE
Display archived scan settings above results

### DIFF
--- a/templates/archive/results.html
+++ b/templates/archive/results.html
@@ -1,15 +1,23 @@
 {% extends 'base.html' %}
 {% block title %}Pattern Finder — Results{% endblock %}
 {% block content %}
-  {% if settings_items %}
+  {% if settings_items or settings_json_pretty %}
   <div class="card" style="margin-bottom:1rem;">
     <div class="card-body">
-      <strong>Settings</strong>
-      <div class="grid" style="margin-top:.5rem;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));font-size:.85rem;">
+      <strong>Exact Settings</strong>
+      {% if settings_items %}
+      <div class="grid" style="margin-top:.5rem;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));font-size:.85rem;gap:.75rem;">
         {% for key, val in settings_items %}
-        <div><span class="muted">{{ key }}</span><br>{{ val }}</div>
+        <div>
+          <div class="muted" style="font-size:.75rem;"><code>{{ key }}</code></div>
+          <div><code>{{ val | tojson }}</code></div>
+        </div>
         {% endfor %}
       </div>
+      {% endif %}
+      {% if settings_json_pretty %}
+      <pre style="margin-top:.75rem;font-size:.8rem;white-space:pre-wrap;background:#0e1117;border:1px solid #1f2937;border-radius:4px;padding:.75rem;">{{ settings_json_pretty }}</pre>
+      {% endif %}
     </div>
   </div>
   {% endif %}

--- a/templates/results_page.html
+++ b/templates/results_page.html
@@ -1,15 +1,23 @@
 {% extends 'base.html' %}
 {% block title %}Pattern Finder — Results{% endblock %}
 {% block content %}
-  {% if settings_items %}
+  {% if settings_items or settings_json_pretty %}
   <div class="card" style="margin-bottom:1rem;">
     <div class="card-body">
-      <strong>Settings</strong>
-      <div class="grid" style="margin-top:.5rem;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));font-size:.85rem;">
+      <strong>Exact Settings</strong>
+      {% if settings_items %}
+      <div class="grid" style="margin-top:.5rem;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));font-size:.85rem;gap:.75rem;">
         {% for key, val in settings_items %}
-        <div><span class="muted">{{ key }}</span><br>{{ val }}</div>
+        <div>
+          <div class="muted" style="font-size:.75rem;"><code>{{ key }}</code></div>
+          <div><code>{{ val | tojson }}</code></div>
+        </div>
         {% endfor %}
       </div>
+      {% endif %}
+      {% if settings_json_pretty %}
+      <pre style="margin-top:.75rem;font-size:.8rem;white-space:pre-wrap;background:#0e1117;border:1px solid #1f2937;border-radius:4px;padding:.75rem;">{{ settings_json_pretty }}</pre>
+      {% endif %}
     </div>
   </div>
   {% endif %}


### PR DESCRIPTION
## Summary
- parse stored scan parameters for archived runs and expose them to the results template
- render an "Exact Settings" card that lists each setting and the raw JSON above the archived results table
- update the shared results page template to keep the settings presentation consistent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b3a316048329ad4b29afd7b85073