### PR TITLE
Surface Wilson metrics in scanner UI

### DIFF
--- a/pattern_finder_app.py
+++ b/pattern_finder_app.py
@@ -1388,9 +1388,24 @@ class App:
         if not sel:
             messagebox.showinfo("Favorites","Select one or more rows to save."); return
         favs=self._load_favs()
+        columns = list(self.tree["columns"])
+        try:
+            node_idx = columns.index("node_id")
+        except ValueError:
+            messagebox.showerror("Favorites", "Unable to locate node_id column.")
+            return
         for iid in sel:
             vals=self.tree.item(iid,"values")
-            node_id=int(vals[9]); row=df[df["node_id"]==node_id]
+            if node_idx >= len(vals):
+                continue
+            node_val = vals[node_idx]
+            if node_val in ("", None):
+                continue
+            try:
+                node_id=int(node_val)
+            except (TypeError, ValueError):
+                continue
+            row=df[df["node_id"]==node_id]
             if row.empty: continue
             favs.append({
                 "ticker":p["ticker"],"interval":p["interval"],


### PR DESCRIPTION
## Summary
- tag simulated trades with hit/stop/timeout outcomes so Wilson bounds and failure breakdowns align with the first event observed for each rule
- add Wilson lower bound, stop%, and timeout% columns to the rules, scanner, and auto-scanner tables so the new metrics are visible across views
- format percentage cells through shared helpers when populating each table to default missing data to 0.00% and keep the hit/Wilson/support order consistent

## Testing
- python -m compileall pattern_finder_app.py

------
https://chatgpt.com/codex/tasks/task_e_68c9d280f5c08329830198df66c2a807