### PR TITLE
Add public SMS consent and policy pages

### DIFF
--- a/alembic/versions/0007_sms_consent.py
+++ b/alembic/versions/0007_sms_consent.py
@@ -1,0 +1,64 @@
+"""Add SMS consent and delivery log tables
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2024-10-01 00:00:00.000000
+"""
+from __future__ import annotations
+
+try:
+    from alembic import op  # type: ignore
+except Exception:  # pragma: no cover - fallback stub
+    from alembic_stub import op
+
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS sms_consent (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            phone_e164 TEXT NOT NULL,
+            consent_text TEXT NOT NULL,
+            consent_at TEXT NOT NULL,
+            ip TEXT,
+            user_agent TEXT,
+            revoked_at TEXT,
+            method TEXT NOT NULL DEFAULT 'settings',
+            verification_id TEXT
+        );
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sms_consent_user ON sms_consent(user_id, revoked_at);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sms_consent_phone ON sms_consent(phone_e164, consent_at DESC);"
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS sms_delivery_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            phone_e164 TEXT NOT NULL,
+            sent_at TEXT NOT NULL,
+            message_type TEXT,
+            body_hash TEXT
+        );
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sms_delivery_user ON sms_delivery_log(user_id, sent_at);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sms_delivery_phone ON sms_delivery_log(phone_e164, sent_at DESC);"
+    )
+
+
+def downgrade() -> None:  # pragma: no cover - destructive downgrade
+    raise RuntimeError("downgrade not supported")

--- a/config.py
+++ b/config.py
@@ -67,6 +67,7 @@ class Settings:
     twilio_account_sid: str = os.getenv("TWILIO_ACCOUNT_SID", "")
     twilio_auth_token: str = os.getenv("TWILIO_AUTH_TOKEN", "")
     twilio_from_number: str = os.getenv("TWILIO_FROM_NUMBER", "")
+    twilio_verify_service_sid: str = os.getenv("TWILIO_VERIFY_SERVICE_SID", "")
     alert_sms_to: Tuple[str, ...] = _csv("ALERT_SMS_TO")
     alert_channel: str = _choice("ALERT_CHANNEL", "Email", allowed=("Email", "MMS"))
     alert_outcomes: str = _choice("ALERT_OUTCOMES", "hit", allowed=("hit", "all"))

--- a/db.py
+++ b/db.py
@@ -268,6 +268,35 @@ SCHEMA = [
         updated_at TEXT
     );
     """,
+    # SMS consent + delivery log
+    """
+    CREATE TABLE IF NOT EXISTS sms_consent (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        phone_e164 TEXT NOT NULL,
+        consent_text TEXT NOT NULL,
+        consent_at TEXT NOT NULL,
+        ip TEXT,
+        user_agent TEXT,
+        revoked_at TEXT,
+        method TEXT NOT NULL DEFAULT 'settings',
+        verification_id TEXT
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_sms_consent_user ON sms_consent(user_id, revoked_at);",
+    "CREATE INDEX IF NOT EXISTS idx_sms_consent_phone ON sms_consent(phone_e164, consent_at DESC);",
+    """
+    CREATE TABLE IF NOT EXISTS sms_delivery_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        phone_e164 TEXT NOT NULL,
+        sent_at TEXT NOT NULL,
+        message_type TEXT,
+        body_hash TEXT
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_sms_delivery_user ON sms_delivery_log(user_id, sent_at);",
+    "CREATE INDEX IF NOT EXISTS idx_sms_delivery_phone ON sms_delivery_log(phone_e164, sent_at DESC);",
 ]
 
 

--- a/services/sms_consent.py
+++ b/services/sms_consent.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+from contextlib import contextmanager
+from datetime import datetime, time, timezone
+from typing import Iterator
+
+from db import get_db, row_to_dict
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_USER_ID = "default"
+DEFAULT_DAILY_LIMIT = 25
+_FOOTER_TEXT = "STOP=opt-out, HELP=help"
+
+
+@contextmanager
+def _db_context(db_cursor):
+    if db_cursor is not None:
+        yield db_cursor
+        return
+
+    gen: Iterator = get_db()
+    cursor = next(gen)
+    try:
+        yield cursor
+        try:
+            next(gen)
+        except StopIteration:
+            pass
+    finally:
+        gen.close()
+
+
+def normalize_phone(raw: str | None) -> str:
+    if not raw:
+        return ""
+    text = str(raw).strip()
+    if not text:
+        return ""
+    if text.startswith("+"):
+        digits = "+" + "".join(ch for ch in text[1:] if ch.isdigit())
+    else:
+        digits_only = "".join(ch for ch in text if ch.isdigit())
+        if not digits_only:
+            return ""
+        if len(digits_only) == 10:
+            digits = "+1" + digits_only
+        elif len(digits_only) == 11 and digits_only.startswith("1"):
+            digits = "+" + digits_only
+        else:
+            digits = "+" + digits_only
+    if len(digits) < 4:
+        return ""
+    return digits
+
+
+def append_footer(body: str) -> str:
+    message = (body or "").strip()
+    if not message:
+        return _FOOTER_TEXT
+    if _FOOTER_TEXT.lower() in message.lower():
+        return message
+    return f"{message}\n\n{_FOOTER_TEXT}"
+
+
+def active_destinations(
+    *, user_id: str | None = None, db_cursor=None
+) -> list[dict[str, object]]:
+    with _db_context(db_cursor) as cursor:
+        if user_id:
+            cursor.execute(
+                "SELECT * FROM sms_consent WHERE user_id=? AND revoked_at IS NULL ORDER BY consent_at DESC",
+                (str(user_id),),
+            )
+        else:
+            cursor.execute(
+                "SELECT * FROM sms_consent WHERE revoked_at IS NULL ORDER BY consent_at DESC"
+            )
+        rows = cursor.fetchall()
+        return [row_to_dict(row, cursor) for row in rows]
+
+
+def active_numbers(*, user_id: str | None = None, db_cursor=None) -> list[str]:
+    destinations = active_destinations(user_id=user_id, db_cursor=db_cursor)
+    return [str(dest.get("phone_e164") or "") for dest in destinations if dest.get("phone_e164")]
+
+
+def latest_for_user(
+    user_id: str | None,
+    *,
+    include_revoked: bool = False,
+    db_cursor=None,
+) -> dict[str, object]:
+    target = str(user_id or DEFAULT_USER_ID)
+    query = "SELECT * FROM sms_consent WHERE user_id=?"
+    if not include_revoked:
+        query += " AND revoked_at IS NULL"
+    query += " ORDER BY consent_at DESC LIMIT 1"
+    with _db_context(db_cursor) as cursor:
+        cursor.execute(query, (target,))
+        row = cursor.fetchone()
+        return row_to_dict(row, cursor) if row else {}
+
+
+def history_for_user(
+    user_id: str | None,
+    *,
+    limit: int = 10,
+    db_cursor=None,
+) -> list[dict[str, object]]:
+    target = str(user_id or DEFAULT_USER_ID)
+    with _db_context(db_cursor) as cursor:
+        cursor.execute(
+            "SELECT * FROM sms_consent WHERE user_id=? ORDER BY consent_at DESC LIMIT ?",
+            (target, int(limit)),
+        )
+        rows = cursor.fetchall()
+        return [row_to_dict(row, cursor) for row in rows]
+
+
+def latest_for_phone(
+    phone: str,
+    *,
+    include_revoked: bool = True,
+    db_cursor=None,
+) -> dict[str, object]:
+    normalized = normalize_phone(phone)
+    if not normalized:
+        return {}
+    query = "SELECT * FROM sms_consent WHERE phone_e164=?"
+    if not include_revoked:
+        query += " AND revoked_at IS NULL"
+    query += " ORDER BY consent_at DESC LIMIT 1"
+    with _db_context(db_cursor) as cursor:
+        cursor.execute(query, (normalized,))
+        row = cursor.fetchone()
+        return row_to_dict(row, cursor) if row else {}
+
+
+def record_consent(
+    user_id: str | None,
+    phone: str,
+    consent_text: str,
+    *,
+    ip: str | None = None,
+    user_agent: str | None = None,
+    verification_id: str | None = None,
+    method: str = "settings",
+    db_cursor=None,
+) -> dict[str, object]:
+    normalized = normalize_phone(phone)
+    if not normalized:
+        raise ValueError("Invalid phone number")
+    consent_text = (consent_text or "").strip()
+    if not consent_text:
+        raise ValueError("Consent text required")
+    method_value = (method or "settings").strip() or "settings"
+    user_value = str(user_id or DEFAULT_USER_ID)
+    now_iso = datetime.now(timezone.utc).isoformat()
+    with _db_context(db_cursor) as cursor:
+        cursor.execute(
+            "UPDATE sms_consent SET revoked_at=? WHERE user_id=? AND revoked_at IS NULL",
+            (now_iso, user_value),
+        )
+        cursor.execute(
+            """
+            INSERT INTO sms_consent (
+                user_id, phone_e164, consent_text, consent_at, ip, user_agent, method, verification_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                user_value,
+                normalized,
+                consent_text,
+                now_iso,
+                ip,
+                user_agent,
+                method_value,
+                verification_id,
+            ),
+        )
+        inserted_id = cursor.lastrowid
+        cursor.execute("SELECT * FROM sms_consent WHERE id=?", (inserted_id,))
+        row = cursor.fetchone()
+        result = row_to_dict(row, cursor) if row else {}
+    logger.info(
+        "sms_consent_recorded",
+        extra={
+            "user_id": user_value,
+            "phone": normalized,
+            "method": method_value,
+        },
+    )
+    return result
+
+
+def revoke_phone(
+    phone: str,
+    *,
+    user_id: str | None = None,
+    db_cursor=None,
+) -> bool:
+    normalized = normalize_phone(phone)
+    if not normalized:
+        return False
+    now_iso = datetime.now(timezone.utc).isoformat()
+    params: list[str] = [now_iso, normalized]
+    query = "UPDATE sms_consent SET revoked_at=? WHERE phone_e164=? AND revoked_at IS NULL"
+    if user_id:
+        query += " AND user_id=?"
+        params.append(str(user_id))
+    with _db_context(db_cursor) as cursor:
+        cursor.execute(query, tuple(params))
+        updated = cursor.rowcount
+    if updated:
+        logger.info("sms_consent_revoked", extra={"phone": normalized, "user_id": user_id})
+    return bool(updated)
+
+
+def allow_sending(
+    phone: str,
+    *,
+    user_id: str | None = None,
+    limit_per_day: int = DEFAULT_DAILY_LIMIT,
+    db_cursor=None,
+) -> tuple[bool, dict[str, object] | None]:
+    normalized = normalize_phone(phone)
+    if not normalized:
+        return False, None
+    with _db_context(db_cursor) as cursor:
+        params: list[str] = [normalized]
+        query = "SELECT * FROM sms_consent WHERE phone_e164=? AND revoked_at IS NULL"
+        if user_id:
+            query += " AND user_id=?"
+            params.append(str(user_id))
+        query += " ORDER BY consent_at DESC LIMIT 1"
+        cursor.execute(query, tuple(params))
+        row = cursor.fetchone()
+        if not row:
+            return False, None
+        consent = row_to_dict(row, cursor)
+        effective_user = str(consent.get("user_id") or user_id or DEFAULT_USER_ID)
+        if limit_per_day:
+            start = datetime.now(timezone.utc)
+            start_of_day = datetime.combine(start.date(), time(0, tzinfo=timezone.utc))
+            cursor.execute(
+                "SELECT COUNT(*) FROM sms_delivery_log WHERE user_id=? AND phone_e164=? AND sent_at >= ?",
+                (effective_user, normalized, start_of_day.isoformat()),
+            )
+            count_row = cursor.fetchone()
+            count = count_row[0] if count_row else 0
+            if count >= limit_per_day:
+                logger.info(
+                    "sms_consent_rate_limited",
+                    extra={"user_id": effective_user, "phone": normalized, "limit": limit_per_day},
+                )
+                return False, consent
+        return True, consent
+
+
+def record_delivery(
+    phone: str,
+    user_id: str | None,
+    body: str,
+    *,
+    message_type: str = "alert",
+    db_cursor=None,
+) -> None:
+    normalized = normalize_phone(phone)
+    if not normalized:
+        return
+    digest = hashlib.sha256((body or "").encode("utf-8")).hexdigest()[:32]
+    now_iso = datetime.now(timezone.utc).isoformat()
+    user_value = str(user_id or DEFAULT_USER_ID)
+    with _db_context(db_cursor) as cursor:
+        cursor.execute(
+            """
+            INSERT INTO sms_delivery_log (user_id, phone_e164, sent_at, message_type, body_hash)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (user_value, normalized, now_iso, message_type, digest),
+        )
+
+
+__all__ = [
+    "DEFAULT_DAILY_LIMIT",
+    "DEFAULT_USER_ID",
+    "active_destinations",
+    "active_numbers",
+    "allow_sending",
+    "append_footer",
+    "history_for_user",
+    "latest_for_phone",
+    "latest_for_user",
+    "normalize_phone",
+    "record_consent",
+    "record_delivery",
+    "revoke_phone",
+]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -938,3 +938,23 @@ select:focus,
 
 #scan-overlay.htmx-request { display:grid !important; }
 .htmx-request #scan-results { opacity:.4; filter:grayscale(30%); }
+
+.site-footer {
+  margin:32px auto 24px;
+  max-width:1200px;
+  padding:0 16px;
+  text-align:center;
+  color:var(--muted);
+  font-size:0.9rem;
+}
+
+.site-footer a {
+  color:var(--accent);
+  text-decoration:none;
+  margin:0 6px;
+}
+
+.site-footer a:hover,
+.site-footer a:focus {
+  text-decoration:underline;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,13 @@
   <div class="wrap">
     {% block content %}{% endblock %}
   </div>
+  <footer class="site-footer">
+    <a href="/sms-consent">SMS Consent</a>
+    <span aria-hidden="true">·</span>
+    <a href="/privacy">Privacy Policy</a>
+    <span aria-hidden="true">·</span>
+    <a href="/terms">Terms of Service</a>
+  </footer>
   {% block extra_body %}{% endblock %}
   <div id="ctx-menu" hidden>
     <button id="ctx-add-fav" class="menu-item">➕ Add to Favorites</button>

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,18 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Privacy Policy — Petra Stock</title></head><body>
+<h1>Privacy Policy</h1>
+<p><strong>Effective Date:</strong> [Insert Date]</p>
+<p>We collect your phone number, consent records (date/time/IP/method), and basic messaging usage solely to send SMS alerts you opted into. We do not sell or share data.</p>
+<h2>Use of Information</h2>
+<ul>
+  <li>Send opted-in SMS alerts</li>
+  <li>Honor STOP/START/HELP and maintain compliance logs</li>
+</ul>
+<h2>Opt-Out</h2>
+<p>Reply <strong>STOP</strong> to any message to cancel. Reply <strong>HELP</strong> for assistance.</p>
+<h2>Retention</h2>
+<p>We retain consent logs for compliance. Request deletion at <a href="mailto:petrasstockalerts@gmail.com">petrasstockalerts@gmail.com</a>.</p>
+<h2>Contact</h2>
+<p>Email: <a href="mailto:petrasstockalerts@gmail.com">petrasstockalerts@gmail.com</a></p>
+</body></html>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -20,6 +20,77 @@
   .recency-halflife input {
     width: 5rem;
   }
+  .sms-card {
+    margin-top: 1rem;
+  }
+  .sms-status {
+    margin: 0.5rem 0 1rem;
+  }
+  .sms-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 280px) auto;
+    align-items: end;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+  .sms-history {
+    margin-top: 1rem;
+  }
+  .sms-history ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .sms-history li {
+    display: flex;
+    flex-direction: column;
+    padding: 0.4rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+  .sms-history li:last-child {
+    border-bottom: none;
+  }
+  .sms-history .status-active {
+    color: var(--pos);
+  }
+  .sms-history .status-revoked {
+    color: var(--neg);
+  }
+  #sms-code-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.65);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 99;
+  }
+  #sms-code-modal[hidden] {
+    display: none;
+  }
+  .modal-card {
+    background: #111;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    padding: 1.5rem;
+    max-width: 22rem;
+    width: 100%;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
+  }
+  .modal-card h3 {
+    margin-top: 0;
+  }
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
+  .btn-secondary {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: inherit;
+  }
 </style>
 {% endblock %}
 {% block content %}
@@ -100,6 +171,55 @@
   </div>
     </form>
   </div>
+  <div class="card sms-card">
+    <div class="card-body">
+      <h2>SMS Alerts (Opt-in)</h2>
+      <p id="sms-status-text" class="note sms-status {{ 'status-success' if sms_state.active else 'status-error' }}">
+        {% if sms_state.active and sms_state.phone %}
+          SMS alerts are enabled for <strong>{{ sms_state.phone }}</strong>.
+        {% else %}
+          SMS alerts are currently disabled. Verify your number to opt in.
+        {% endif %}
+      </p>
+      <label class="checkbox" style="gap:0.5rem; align-items:flex-start;">
+        <input type="checkbox" id="sms-consent-checkbox" />
+        <span id="sms-consent-copy" data-consent="{{ sms_consent_text }}">{{ sms_consent_text }}</span>
+      </label>
+      <div class="sms-grid">
+        <div>
+          <label for="sms-phone">Phone number</label>
+          <input id="sms-phone" type="tel" value="{{ sms_state.phone or '' }}" placeholder="+1 555 555 1212" />
+        </div>
+        <div>
+          <button id="sms-verify-btn" type="button">Verify &amp; Opt-in</button>
+        </div>
+      </div>
+      <div class="sms-history">
+        <strong>History</strong>
+        <ul id="sms-history-list">
+          {% if sms_state.history %}
+            {% for item in sms_state.history %}
+              <li>
+                <span><strong>{{ item.phone_e164 }}</strong></span>
+                <span class="{{ 'status-revoked' if item.revoked_at else 'status-active' }}">
+                  {% if item.revoked_at %}
+                    Revoked {{ item.revoked_at }}
+                  {% else %}
+                    Active since {{ item.consent_at }}
+                  {% endif %}
+                </span>
+                <span class="note" style="margin-top:0.25rem;">
+                  Method: {{ item.method }}{% if item.verification_id %} • Verification {{ item.verification_id }}{% endif %}
+                </span>
+              </li>
+            {% endfor %}
+          {% else %}
+            <li><span class="note">No SMS consent records yet.</span></li>
+          {% endif %}
+        </ul>
+      </div>
+    </div>
+  </div>
   <div class="card" style="margin-top:1rem;">
     <div class="card-body">
       <strong>Favorites Alerts</strong>
@@ -126,6 +246,18 @@
       <button id="send_test_alert" class="btn" style="margin-top:.75rem;">Send Test Alert</button>
     </div>
   </div>
+  <div id="sms-code-modal" hidden>
+    <div class="modal-card">
+      <h3>Enter verification code</h3>
+      <p class="note">We sent a verification code via SMS. Enter it below to confirm your opt-in.</p>
+      <input id="sms-code-input" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="8" placeholder="123456" />
+      <div class="modal-actions">
+        <button type="button" id="sms-code-submit">Confirm</button>
+        <button type="button" id="sms-code-cancel" class="btn-secondary">Cancel</button>
+      </div>
+    </div>
+  </div>
+  <script type="application/json" id="sms-state-data">{{ sms_state|tojson|safe }}</script>
 {% endblock %}
 {% block extra_body %}
 <script>
@@ -144,6 +276,89 @@
     const symbolInput = document.getElementById('fav_symbol');
     const channelSelect = document.getElementById('test_channel');
     const outcomesSelect = document.getElementById('test_outcomes');
+    const smsStateEl = document.getElementById('sms-state-data');
+    let smsState = {};
+    try {
+      smsState = JSON.parse(smsStateEl?.textContent || '{}') || {};
+    } catch (err) {
+      smsState = {};
+    }
+    const smsStatusEl = document.getElementById('sms-status-text');
+    const smsHistoryList = document.getElementById('sms-history-list');
+    const smsCheckbox = document.getElementById('sms-consent-checkbox');
+    const smsPhoneInput = document.getElementById('sms-phone');
+    const smsVerifyBtn = document.getElementById('sms-verify-btn');
+    const smsModal = document.getElementById('sms-code-modal');
+    const smsCodeInput = document.getElementById('sms-code-input');
+    const smsCodeSubmit = document.getElementById('sms-code-submit');
+    const smsCodeCancel = document.getElementById('sms-code-cancel');
+    const consentCopyEl = document.getElementById('sms-consent-copy');
+    const consentCopy = consentCopyEl?.dataset?.consent || '';
+    let pendingPhone = null;
+
+    function renderSmsHistory() {
+      if (!smsHistoryList) return;
+      const history = Array.isArray(smsState?.history) ? smsState.history : [];
+      if (!history.length) {
+        smsHistoryList.innerHTML = '<li><span class="note">No SMS consent records yet.</span></li>';
+        return;
+      }
+      const items = history.map((item) => {
+        const phone = item?.phone_e164 || '';
+        const revoked = item?.revoked_at;
+        const consentAt = item?.consent_at || '';
+        const method = item?.method || '';
+        const verificationId = item?.verification_id ? ` • Verification ${item.verification_id}` : '';
+        const statusClass = revoked ? 'status-revoked' : 'status-active';
+        const statusText = revoked ? `Revoked ${revoked}` : `Active since ${consentAt}`;
+        return `
+          <li>
+            <span><strong>${phone}</strong></span>
+            <span class="${statusClass}">${statusText}</span>
+            <span class="note" style="margin-top:0.25rem;">Method: ${method}${verificationId}</span>
+          </li>
+        `;
+      });
+      smsHistoryList.innerHTML = items.join('');
+    }
+
+    function renderSmsState() {
+      if (smsStatusEl) {
+        if (smsState?.active && smsState?.phone) {
+          smsStatusEl.classList.add('status-success');
+          smsStatusEl.classList.remove('status-error');
+          smsStatusEl.innerHTML = `SMS alerts are enabled for <strong>${smsState.phone}</strong>.`;
+        } else {
+          smsStatusEl.classList.remove('status-success');
+          smsStatusEl.classList.add('status-error');
+          smsStatusEl.textContent = 'SMS alerts are currently disabled. Verify your number to opt in.';
+        }
+      }
+      if (smsCheckbox) {
+        smsCheckbox.checked = Boolean(smsState?.active);
+      }
+      renderSmsHistory();
+    }
+
+    function openSmsModal() {
+      if (!smsModal) return;
+      smsModal.removeAttribute('hidden');
+      setTimeout(() => smsCodeInput?.focus(), 10);
+    }
+
+    function closeSmsModal() {
+      if (smsModal) {
+        smsModal.setAttribute('hidden', '');
+      }
+      if (smsCodeInput) {
+        smsCodeInput.value = '';
+      }
+    }
+
+    renderSmsState();
+    if (smsState?.phone && smsPhoneInput) {
+      smsPhoneInput.value = smsState.phone;
+    }
 
     sendBtn?.addEventListener('click', async () => {
       const symbol = (symbolInput?.value || '').trim().toUpperCase();
@@ -172,6 +387,113 @@
         showToast(err?.message || 'Failed to send test alert', false);
       } finally {
         sendBtn.disabled = false;
+      }
+    });
+
+    smsVerifyBtn?.addEventListener('click', async () => {
+      if (!smsCheckbox?.checked) {
+        showToast('You must agree to the SMS consent before opting in.', false);
+        return;
+      }
+      const phone = (smsPhoneInput?.value || '').trim();
+      if (!phone) {
+        showToast('Enter a phone number to verify.', false);
+        return;
+      }
+      smsVerifyBtn.disabled = true;
+      try {
+        const res = await fetch('/api/sms/verify/start', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ phone, consent_text: consentCopy, method: 'settings' }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data?.ok) {
+          throw new Error(data?.error || 'Failed to start verification');
+        }
+        pendingPhone = data.phone || phone;
+        if (smsPhoneInput) {
+          smsPhoneInput.value = pendingPhone;
+        }
+        openSmsModal();
+        showToast('Verification code sent. Check your phone.');
+      } catch (err) {
+        showToast(err?.message || 'Failed to start verification', false);
+      } finally {
+        smsVerifyBtn.disabled = false;
+      }
+    });
+
+    smsCodeSubmit?.addEventListener('click', async () => {
+      const code = (smsCodeInput?.value || '').trim();
+      if (!code) {
+        showToast('Enter the verification code.', false);
+        return;
+      }
+      const phoneValue = pendingPhone || (smsPhoneInput?.value || '').trim();
+      smsCodeSubmit.disabled = true;
+      try {
+        const res = await fetch('/api/sms/verify/check', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            phone: phoneValue,
+            code,
+            consent_text: consentCopy,
+            method: 'settings',
+          }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data?.ok) {
+          throw new Error(data?.error || 'Verification failed');
+        }
+        const record = data?.consent || {};
+        const existingHistory = Array.isArray(smsState?.history)
+          ? smsState.history.filter((item) => item?.id !== record?.id)
+          : [];
+        smsState = {
+          ...smsState,
+          active: true,
+          phone: record?.phone_e164 || phoneValue,
+          consent_at: record?.consent_at,
+          method: record?.method,
+          user_id: record?.user_id || smsState?.user_id,
+          history: [record, ...existingHistory],
+        };
+        pendingPhone = null;
+        renderSmsState();
+        closeSmsModal();
+        showToast('SMS alerts enabled.');
+      } catch (err) {
+        showToast(err?.message || 'Verification failed', false);
+      } finally {
+        smsCodeSubmit.disabled = false;
+      }
+    });
+
+    smsCodeCancel?.addEventListener('click', () => {
+      pendingPhone = null;
+      closeSmsModal();
+    });
+
+    smsModal?.addEventListener('click', (event) => {
+      if (event.target === smsModal) {
+        pendingPhone = null;
+        closeSmsModal();
+      }
+    });
+
+    smsCodeInput?.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        smsCodeSubmit?.click();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !smsModal?.hasAttribute('hidden')) {
+        pendingPhone = null;
+        closeSmsModal();
       }
     });
   })();

--- a/templates/sms_consent.html
+++ b/templates/sms_consent.html
@@ -1,0 +1,23 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Petra Stock — SMS Consent</title>
+</head><body>
+<h1>SMS Alerts Opt-In</h1>
+<p>Enable text alerts for trading patterns. Msg & data rates may apply. Max messages vary by settings.
+Reply STOP to cancel, HELP for help.</p>
+
+<form method="post" action="/api/sms/verify/start" style="max-width:480px">
+  <label>Phone number (E.164, e.g., +15551234567)
+    <input required name="phone" type="tel" style="width:100%">
+  </label><br><br>
+  <label><input required type="checkbox" name="consent">
+    I agree to receive SMS alerts from Petra Stock and to the
+    <a href="/terms" target="_blank">Terms</a> and
+    <a href="/privacy" target="_blank">Privacy Policy</a>.
+  </label><br><br>
+  <button type="submit">Send Verification Code</button>
+</form>
+
+<hr>
+<p>Support: <a href="mailto:petrasstockalerts@gmail.com">petrasstockalerts@gmail.com</a></p>
+</body></html>

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -1,0 +1,19 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Terms of Service — Petra Stock</title></head><body>
+<h1>Terms of Service</h1>
+<p><strong>Effective Date:</strong> [Insert Date]</p>
+<h2>Service</h2>
+<p>Petra Stock sends trading-alert SMS to users who explicitly opt in and verify their number. Message/data rates may apply. Frequency varies by settings.</p>
+<h2>Responsibilities</h2>
+<ul>
+  <li>Provide an accurate phone number.</li>
+  <li>Use STOP to opt out; HELP for assistance.</li>
+</ul>
+<h2>Liability</h2>
+<p>Alerts are informational only. We are not responsible for trading outcomes.</p>
+<h2>Changes</h2>
+<p>We may update these terms at this URL.</p>
+<h2>Contact</h2>
+<p>Email: <a href="mailto:petrasstockalerts@gmail.com">petrasstockalerts@gmail.com</a></p>
+</body></html>

--- a/tests/test_favorites_test_alert.py
+++ b/tests/test_favorites_test_alert.py
@@ -36,8 +36,28 @@ def configure_settings(
         monkeypatch.setattr(routes.settings, "alert_sms_to", sms_to)
 
 
+def stub_sms_consent(monkeypatch, numbers: tuple[str, ...]):
+    records = [
+        {"phone_e164": num, "user_id": f"user-{idx + 1}"}
+        for idx, num in enumerate(numbers)
+    ]
+
+    monkeypatch.setattr(
+        routes.sms_consent,
+        "active_destinations",
+        lambda **kwargs: list(records),
+    )
+    monkeypatch.setattr(
+        routes.sms_consent,
+        "allow_sending",
+        lambda number, **kwargs: (True, {"user_id": "user-1", "phone_e164": number}),
+    )
+    monkeypatch.setattr(routes.sms_consent, "record_delivery", lambda *args, **kwargs: None)
+
+
 def test_favorites_test_alert_mms(tmp_path, monkeypatch):
     configure_settings(monkeypatch, channel="MMS", outcomes="all", sms_to=("18005550100",))
+    stub_sms_consent(monkeypatch, ("18005550100",))
 
     send_calls: list[tuple[str, str, dict | None]] = []
 
@@ -76,8 +96,9 @@ def test_favorites_test_alert_mms(tmp_path, monkeypatch):
         "compact": False,
         "outcomes": "all",
     }
-    assert send_calls[0][0] == "18005550100"
+    assert send_calls[0][0] == "+18005550100"
     assert send_calls[0][2]["channel"] == "mms"
+    assert send_calls[0][1].endswith("STOP=opt-out, HELP=help")
     assert events[-2] == {
         "type": "favorites_test_alert_send",
         "channel": "mms",
@@ -96,6 +117,7 @@ def test_favorites_test_alert_mms(tmp_path, monkeypatch):
 
 def test_settings_test_alert_overrides(tmp_path, monkeypatch):
     configure_settings(monkeypatch, channel="Email", outcomes="hit", sms_to=("18005550100",))
+    stub_sms_consent(monkeypatch, ("18005550100",))
 
     sent: list[tuple[str, str, dict | None]] = []
 
@@ -136,7 +158,8 @@ def test_settings_test_alert_overrides(tmp_path, monkeypatch):
         "compact": False,
         "outcomes": "all",
     }
-    assert sent and sent[0][0] == "18005550100"
+    assert sent and sent[0][0] == "+18005550100"
+    assert sent[0][1].endswith("STOP=opt-out, HELP=help")
     assert events[-1]["outcomes"] == "all"
 
 
@@ -308,6 +331,7 @@ def test_preview_returns_body_subject(tmp_path, monkeypatch):
 
 def test_favorites_test_alert_mms_real_layout(tmp_path, monkeypatch):
     configure_settings(monkeypatch, channel="MMS", outcomes="hit", sms_to=("18005550100",))
+    stub_sms_consent(monkeypatch, ("18005550100",))
 
     def fake_send(number, body, *, context=None):
         return True
@@ -338,6 +362,7 @@ def test_favorites_test_alert_mms_real_layout(tmp_path, monkeypatch):
 
 def test_favorites_test_alert_mms_compact_only_failures(tmp_path, monkeypatch):
     configure_settings(monkeypatch, channel="MMS", outcomes="hit", sms_to=("18005550100",))
+    stub_sms_consent(monkeypatch, ("18005550100",))
 
     def fake_send(number, body, *, context=None):
         return True

--- a/tests/test_sms_opt_in.py
+++ b/tests/test_sms_opt_in.py
@@ -1,0 +1,175 @@
+import html
+import sqlite3
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import db
+import routes
+from services import sms_consent
+
+
+def build_client(tmp_path, monkeypatch):
+    db.DB_PATH = str(tmp_path / "sms.db")
+    db.init_db()
+    app = FastAPI()
+    app.include_router(routes.router)
+    return TestClient(app)
+
+
+def test_sms_verify_flow_records_consent(tmp_path, monkeypatch):
+    client = build_client(tmp_path, monkeypatch)
+
+    monkeypatch.setattr(routes.twilio_client, "start_verification", lambda phone: "ver-start")
+    monkeypatch.setattr(
+        routes.twilio_client,
+        "check_verification",
+        lambda phone, code: (code == "123456", "ver-check"),
+    )
+
+    res = client.post(
+        "/api/sms/verify/start",
+        json={"phone": "(800) 555-1212", "consent_text": "I agree."},
+        headers={"user-agent": "pytest"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["ok"]
+    assert data["phone"] == "+18005551212"
+
+    res = client.post(
+        "/api/sms/verify/check",
+        json={
+            "phone": "800-555-1212",
+            "code": "123456",
+            "consent_text": "I agree.",
+        },
+        headers={"user-agent": "pytest"},
+    )
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["ok"] is True
+    consent = payload["consent"]
+    assert consent["phone_e164"] == "+18005551212"
+    assert consent["verification_id"] == "ver-check"
+    assert consent["method"] == "settings"
+
+    conn = sqlite3.connect(db.DB_PATH)
+    row = conn.execute(
+        "SELECT phone_e164, consent_text, method, revoked_at FROM sms_consent"
+    ).fetchone()
+    conn.close()
+    assert row[0] == "+18005551212"
+    assert row[1] == "I agree."
+    assert row[2] == "settings"
+    assert row[3] is None
+
+
+def test_sms_reverify_creates_history(tmp_path, monkeypatch):
+    client = build_client(tmp_path, monkeypatch)
+
+    monkeypatch.setattr(routes.twilio_client, "start_verification", lambda phone: "sid-1")
+    monkeypatch.setattr(
+        routes.twilio_client,
+        "check_verification",
+        lambda phone, code: (True, f"ver-{phone[-4:]}")
+    )
+
+    client.post(
+        "/api/sms/verify/start",
+        json={"phone": "+1 (800) 555-1212", "consent_text": "Consent"},
+    )
+    client.post(
+        "/api/sms/verify/check",
+        json={"phone": "+18005551212", "code": "000000", "consent_text": "Consent"},
+    )
+
+    client.post(
+        "/api/sms/verify/start",
+        json={"phone": "800-555-1333", "consent_text": "Consent"},
+    )
+    client.post(
+        "/api/sms/verify/check",
+        json={"phone": "8005551333", "code": "000000", "consent_text": "Consent"},
+    )
+
+    conn = sqlite3.connect(db.DB_PATH)
+    rows = conn.execute(
+        "SELECT phone_e164, revoked_at FROM sms_consent ORDER BY consent_at"
+    ).fetchall()
+    conn.close()
+    assert len(rows) == 2
+    assert rows[0][0] == "+18005551212"
+    assert rows[0][1] is not None  # first entry revoked when new number added
+    assert rows[1][0] == "+18005551333"
+    assert rows[1][1] is None
+
+
+def test_inbound_keywords_and_codes(tmp_path, monkeypatch):
+    client = build_client(tmp_path, monkeypatch)
+
+    start_calls: list[str] = []
+
+    def fake_start(phone: str) -> str:
+        start_calls.append(phone)
+        return "start-sid"
+
+    def fake_check(phone: str, code: str) -> tuple[bool, str | None]:
+        return (code == "123456", "verify-sid")
+
+    monkeypatch.setattr(routes.twilio_client, "start_verification", fake_start)
+    monkeypatch.setattr(routes.twilio_client, "check_verification", fake_check)
+
+    sms_consent.record_consent("user-x", "+18005551212", "Consent text")
+
+    res = client.post(
+        "/twilio/inbound-sms",
+        data={"From": "+18005551212", "Body": "STOP"},
+    )
+    assert res.status_code == 200
+    assert "opted out" in res.text
+
+    conn = sqlite3.connect(db.DB_PATH)
+    revoked = conn.execute(
+        "SELECT revoked_at FROM sms_consent ORDER BY consent_at DESC LIMIT 1"
+    ).fetchone()[0]
+    conn.close()
+    assert revoked is not None
+
+    res = client.post(
+        "/twilio/inbound-sms",
+        data={"From": "+18005551212", "Body": "START"},
+    )
+    assert res.status_code == 200
+    assert "verification code" in res.text
+    assert start_calls == ["+18005551212"]
+
+    res = client.post(
+        "/twilio/inbound-sms",
+        data={"From": "+18005551212", "Body": "123456"},
+    )
+    assert res.status_code == 200
+    assert "opted in" in res.text
+
+    rows = sms_consent.history_for_user("user-x")
+    assert len(rows) == 2
+    assert rows[0]["method"] == "sms-keyword"
+    assert rows[0]["verification_id"] == "verify-sid"
+
+    res = client.post(
+        "/twilio/inbound-sms",
+        data={"From": "+18005551212", "Body": "HELP"},
+    )
+    assert res.status_code == 200
+    assert "Msg&data rates may apply" in html.unescape(res.text)
+
+
+def test_allow_sending_rate_limit(tmp_path):
+    db.DB_PATH = str(tmp_path / "rate.db")
+    db.init_db()
+    sms_consent.record_consent("rate-user", "+18005550000", "Consent")
+
+    ok, _ = sms_consent.allow_sending("+18005550000", limit_per_day=1)
+    assert ok is True
+    sms_consent.record_delivery("+18005550000", "rate-user", "body")
+    ok, _ = sms_consent.allow_sending("+18005550000", limit_per_day=1)
+    assert ok is False


### PR DESCRIPTION
## Summary
- add unauthenticated GET routes for the SMS consent, privacy, and terms pages
- provide static templates for SMS consent, privacy policy, and terms content for review
- surface footer links site-wide with styling so the public pages are easy to reach

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1ae7f17ec8329a1bc9f23e593f0c3