### PR TITLE
Add Schwab OAuth login flow

### DIFF
--- a/alembic/versions/0008_oauth_tokens.py
+++ b/alembic/versions/0008_oauth_tokens.py
@@ -1,0 +1,37 @@
+"""Add OAuth token storage table
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2024-11-01 00:00:00.000000
+"""
+from __future__ import annotations
+
+try:
+    from alembic import op  # type: ignore
+except Exception:  # pragma: no cover - fallback stub
+    from alembic_stub import op
+
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS oauth_tokens (
+            provider TEXT PRIMARY KEY,
+            created_at TEXT NOT NULL,
+            refresh_token TEXT NOT NULL,
+            account_id TEXT
+        );
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_oauth_tokens_created_at ON oauth_tokens(created_at);"
+    )
+
+
+def downgrade() -> None:  # pragma: no cover - destructive downgrade
+    raise RuntimeError("downgrade not supported")

--- a/config.py
+++ b/config.py
@@ -118,7 +118,6 @@ if settings.data_provider.lower() == "schwab":
         "SCHWAB_CLIENT_SECRET": settings.schwab_client_secret,
         "SCHWAB_REDIRECT_URI": settings.schwab_redirect_uri,
         "SCHWAB_ACCOUNT_ID": settings.schwab_account_id,
-        "SCHWAB_REFRESH_TOKEN": settings.schwab_refresh_token,
     }
     missing = sorted(name for name, value in required.items() if not value)
     if missing:
@@ -127,3 +126,8 @@ if settings.data_provider.lower() == "schwab":
             "Missing required Schwab configuration: "
             f"{joined}. Set the environment variables or change DATA_PROVIDER."
         )
+
+    if not settings.schwab_refresh_token:
+        # Allow the application to continue without a refresh token so the
+        # interactive OAuth flow can populate it later.
+        setattr(settings, "SCHWAB_REFRESH_TOKEN", "")

--- a/db.py
+++ b/db.py
@@ -297,6 +297,15 @@ SCHEMA = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_sms_delivery_user ON sms_delivery_log(user_id, sent_at);",
     "CREATE INDEX IF NOT EXISTS idx_sms_delivery_phone ON sms_delivery_log(phone_e164, sent_at DESC);",
+    """
+    CREATE TABLE IF NOT EXISTS oauth_tokens (
+        provider TEXT PRIMARY KEY,
+        created_at TEXT NOT NULL,
+        refresh_token TEXT NOT NULL,
+        account_id TEXT
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_oauth_tokens_created_at ON oauth_tokens(created_at);",
 ]
 
 

--- a/services/oauth_tokens.py
+++ b/services/oauth_tokens.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Iterator
+
+from db import get_db
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _db_context(db_cursor):
+    if db_cursor is not None:
+        yield db_cursor
+        return
+
+    gen: Iterator = get_db()
+    cursor = next(gen)
+    try:
+        yield cursor
+        try:
+            next(gen)
+        except StopIteration:
+            pass
+    finally:
+        gen.close()
+
+
+def store_refresh_token(
+    provider: str,
+    refresh_token: str,
+    *,
+    account_id: str | None = None,
+    db_cursor=None,
+) -> None:
+    if not provider:
+        raise ValueError("provider is required")
+    if not refresh_token:
+        raise ValueError("refresh_token is required")
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    with _db_context(db_cursor) as cursor:
+        cursor.execute(
+            """
+            INSERT INTO oauth_tokens(provider, created_at, refresh_token, account_id)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(provider) DO UPDATE SET
+                created_at=excluded.created_at,
+                refresh_token=excluded.refresh_token,
+                account_id=excluded.account_id
+            """,
+            (provider, timestamp, refresh_token, account_id),
+        )
+    logger.info("oauth_token_saved provider=%s", provider)
+
+
+def latest_refresh_token(
+    provider: str,
+    *,
+    db_cursor=None,
+) -> str:
+    if not provider:
+        return ""
+
+    with _db_context(db_cursor) as cursor:
+        cursor.execute(
+            "SELECT refresh_token FROM oauth_tokens WHERE provider=? ORDER BY created_at DESC LIMIT 1",
+            (provider,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return ""
+        if isinstance(row, dict):  # pragma: no cover - sqlite3.Row in tests
+            return str(row.get("refresh_token") or "")
+        try:
+            return str(row[0] or "")
+        except (IndexError, TypeError):  # pragma: no cover - defensive
+            return ""

--- a/tests/test_schwab_oauth.py
+++ b/tests/test_schwab_oauth.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import urllib.parse
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import app
+from config import settings
+from db import get_db
+from services import http_client
+from services import schwab_client
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, payload: dict | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.content = json.dumps(self._payload).encode()
+        self.text = json.dumps(self._payload)
+
+    def json(self) -> dict:
+        return self._payload
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _extract_state(location: str) -> str:
+    parsed = urllib.parse.urlparse(location)
+    query = urllib.parse.parse_qs(parsed.query)
+    return query.get("state", [""])[0]
+
+
+def test_login_redirects_with_pkce(client: TestClient):
+    resp = client.get("/schwab/login", follow_redirects=False)
+    assert resp.status_code in (302, 303, 307)
+    location = resp.headers.get("location")
+    assert location
+    parsed = urllib.parse.urlparse(location)
+    assert parsed.path.endswith("/oauth2/v1/authorize")
+    query = urllib.parse.parse_qs(parsed.query)
+    assert query.get("client_id") == [settings.schwab_client_id]
+    assert query.get("redirect_uri") == [settings.schwab_redirect_uri]
+    assert query.get("response_type") == ["code"]
+    assert query.get("code_challenge_method") == ["S256"]
+    assert query.get("code_challenge")
+    assert query.get("state")
+
+
+def test_callback_exchanges_code_and_stores_refresh_token(monkeypatch, client: TestClient):
+    login = client.get("/schwab/login", follow_redirects=False)
+    state = _extract_state(login.headers["location"])
+
+    captured: dict[str, object] = {}
+    original_token = settings.schwab_refresh_token
+
+    async def fake_request(method, url, **kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["data"] = kwargs.get("data")
+        return DummyResponse(200, {"refresh_token": "new-refresh", "access_token": "token"})
+
+    monkeypatch.setattr(http_client, "request", fake_request)
+
+    resp = client.get("/callback", params={"state": state, "code": "auth-code"})
+    assert resp.status_code == 200
+    assert "Schwab linked" in resp.text
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == schwab_client.TOKEN_URL
+    payload = captured["data"]
+    assert isinstance(payload, dict)
+    assert payload["code"] == "auth-code"
+    assert payload["code_verifier"]
+
+    gen = get_db()
+    cursor = next(gen)
+    try:
+        cursor.execute(
+            "SELECT provider, refresh_token FROM oauth_tokens WHERE provider=?", ("schwab",)
+        )
+        row = cursor.fetchone()
+    finally:
+        try:
+            next(gen)
+        except StopIteration:
+            pass
+        gen.close()
+
+    assert row is not None
+    assert row["provider"] == "schwab"
+    assert row["refresh_token"] == "new-refresh"
+    assert settings.schwab_refresh_token == "new-refresh"
+
+    # Restore configuration for subsequent tests.
+    settings.schwab_refresh_token = original_token
+    setattr(settings, "SCHWAB_REFRESH_TOKEN", original_token)
+    schwab_client.update_refresh_token(original_token)
+
+
+def test_callback_rejects_invalid_state(client: TestClient):
+    resp = client.get("/callback", params={"state": "bogus", "code": "x"})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- add Schwab login and callback routes that implement PKCE, token exchange, and a success page
- persist Schwab refresh tokens in a new oauth_tokens table and expose helpers to manage them
- update the Schwab client to load and refresh stored tokens and cover the flow with tests

## Testing
- pytest tests/test_schwab_oauth.py tests/test_schwab_client.py tests/test_app_boot.py

------
https://chatgpt.com/codex/tasks/task_e_68d2d360c9a483298e0fab8b15381491