### PR TITLE
Update SMS verify flow and compliance copy

### DIFF
--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -2,12 +2,12 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Privacy Policy — Petra Stock</title></head><body>
 <h1>Privacy Policy</h1>
-<p><strong>Effective Date:</strong> [Insert Date]</p>
-<p>We collect your phone number, consent records (date/time/IP/method), and basic messaging usage solely to send SMS alerts you opted into. We do not sell or share data.</p>
+<p><strong>Effective Date:</strong> September 23, 2025</p>
+<p>Petra Stock collects: phone number, consent records (date/time, IP, user agent, method), and basic messaging metadata (delivery status, opt-out events). We do not sell or share personal data.</p>
 <h2>Use of Information</h2>
 <ul>
-  <li>Send opted-in SMS alerts</li>
-  <li>Honor STOP/START/HELP and maintain compliance logs</li>
+  <li>Send the SMS alerts you explicitly requested.</li>
+  <li>Honor STOP/START/HELP and maintain compliance/audit logs.</li>
 </ul>
 <h2>Opt-Out</h2>
 <p>Reply <strong>STOP</strong> to any message to cancel. Reply <strong>HELP</strong> for assistance.</p>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -183,7 +183,13 @@
       </p>
       <label class="checkbox" style="gap:0.5rem; align-items:flex-start;">
         <input type="checkbox" id="sms-consent-checkbox" />
-        <span id="sms-consent-copy" data-consent="{{ sms_consent_text }}">{{ sms_consent_text }}</span>
+        <span id="sms-consent-copy" data-consent="{{ sms_consent_text }}">
+          I agree to receive automated Petra Stock SMS alerts. Msg &amp; data rates may apply.
+          By checking this box, I agree to the
+          <a href="/terms" target="_blank" rel="noopener">Terms</a>
+          and <a href="/privacy" target="_blank" rel="noopener">Privacy Policy</a>.
+          <span class="note" style="display:block; margin-top:0.5rem;">Reply STOP to opt out, HELP for help.</span>
+        </span>
       </label>
       <div class="sms-grid">
         <div>
@@ -194,6 +200,7 @@
           <button id="sms-verify-btn" type="button">Verify &amp; Opt-in</button>
         </div>
       </div>
+      <p id="sms-verify-error" class="note status-error" hidden></p>
       <div class="sms-history">
         <strong>History</strong>
         <ul id="sms-history-list">
@@ -294,6 +301,9 @@
     const smsCodeCancel = document.getElementById('sms-code-cancel');
     const consentCopyEl = document.getElementById('sms-consent-copy');
     const consentCopy = consentCopyEl?.dataset?.consent || '';
+    const smsErrorEl = document.getElementById('sms-verify-error');
+    const phoneRegex = /^\+\d{10,15}$/;
+    let smsStartPending = false;
     let pendingPhone = null;
 
     function renderSmsHistory() {
@@ -360,6 +370,35 @@
       smsPhoneInput.value = smsState.phone;
     }
 
+    const setSmsError = (message) => {
+      if (!smsErrorEl) return;
+      if (message) {
+        smsErrorEl.textContent = message;
+        smsErrorEl.removeAttribute('hidden');
+      } else {
+        smsErrorEl.textContent = '';
+        smsErrorEl.setAttribute('hidden', '');
+      }
+    };
+
+    const updateSmsButtonState = () => {
+      if (!smsVerifyBtn) return;
+      const phoneValue = (smsPhoneInput?.value || '').trim();
+      const consentChecked = Boolean(smsCheckbox?.checked);
+      const phoneValid = phoneRegex.test(phoneValue);
+      smsVerifyBtn.disabled = smsStartPending || !consentChecked || !phoneValid;
+    };
+
+    smsCheckbox?.addEventListener('change', () => {
+      setSmsError('');
+      updateSmsButtonState();
+    });
+
+    smsPhoneInput?.addEventListener('input', () => {
+      setSmsError('');
+      updateSmsButtonState();
+    });
+
     sendBtn?.addEventListener('click', async () => {
       const symbol = (symbolInput?.value || '').trim().toUpperCase();
       if (!symbol) {
@@ -391,38 +430,50 @@
     });
 
     smsVerifyBtn?.addEventListener('click', async () => {
-      if (!smsCheckbox?.checked) {
-        showToast('You must agree to the SMS consent before opting in.', false);
-        return;
-      }
       const phone = (smsPhoneInput?.value || '').trim();
-      if (!phone) {
-        showToast('Enter a phone number to verify.', false);
+      setSmsError('');
+      if (!smsCheckbox?.checked || !phoneRegex.test(phone)) {
+        updateSmsButtonState();
         return;
       }
-      smsVerifyBtn.disabled = true;
+      smsStartPending = true;
+      updateSmsButtonState();
       try {
         const res = await fetch('/api/sms/verify/start', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ phone, consent_text: consentCopy, method: 'settings' }),
+          body: JSON.stringify({
+            phone,
+            consent: true,
+            consent_text: consentCopy,
+            method: 'settings',
+          }),
         });
-        const data = await res.json();
+        const data = await res.json().catch(() => ({}));
         if (!res.ok || !data?.ok) {
-          throw new Error(data?.error || 'Failed to start verification');
+          const message = data?.error || 'Failed to start verification';
+          if (res.status >= 400 && res.status < 500) {
+            setSmsError(message);
+            return;
+          }
+          throw new Error(message);
         }
-        pendingPhone = data.phone || phone;
+        pendingPhone = phone;
         if (smsPhoneInput) {
           smsPhoneInput.value = pendingPhone;
         }
         openSmsModal();
-        showToast('Verification code sent. Check your phone.');
+        showToast('Code sent. Check your texts.');
       } catch (err) {
-        showToast(err?.message || 'Failed to start verification', false);
+        const message = err?.message || 'Failed to start verification';
+        showToast(message, false);
       } finally {
-        smsVerifyBtn.disabled = false;
+        smsStartPending = false;
+        updateSmsButtonState();
       }
     });
+
+    updateSmsButtonState();
 
     smsCodeSubmit?.addEventListener('click', async () => {
       const code = (smsCodeInput?.value || '').trim();

--- a/templates/sms_consent.html
+++ b/templates/sms_consent.html
@@ -11,10 +11,12 @@ Reply STOP to cancel, HELP for help.</p>
     <input required name="phone" type="tel" style="width:100%">
   </label><br><br>
   <label><input required type="checkbox" name="consent">
-    I agree to receive SMS alerts from Petra Stock and to the
-    <a href="/terms" target="_blank">Terms</a> and
-    <a href="/privacy" target="_blank">Privacy Policy</a>.
-  </label><br><br>
+    I agree to receive automated Petra Stock SMS alerts. Msg &amp; data rates may apply. By checking this box, I agree to the
+    <a href="/terms" target="_blank" rel="noopener">Terms</a> and
+    <a href="/privacy" target="_blank" rel="noopener">Privacy Policy</a>.
+  </label>
+  <p>Reply <strong>STOP</strong> to opt out, <strong>HELP</strong> for help.</p>
+  <br>
   <button type="submit">Send Verification Code</button>
 </form>
 

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -2,16 +2,20 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Terms of Service — Petra Stock</title></head><body>
 <h1>Terms of Service</h1>
-<p><strong>Effective Date:</strong> [Insert Date]</p>
+<p><strong>Effective Date:</strong> September 23, 2025</p>
 <h2>Service</h2>
-<p>Petra Stock sends trading-alert SMS to users who explicitly opt in and verify their number. Message/data rates may apply. Frequency varies by settings.</p>
+<p>Petra Stock sends trading-alert SMS to users who explicitly opt in and verify their number. Message and data rates may apply. <strong>Message frequency varies by market activity and your settings, typically up to 10 msgs/day.</strong></p>
+<h2>Opt-Out &amp; Help</h2>
+<p>Reply <strong>STOP</strong> to opt out at any time. Reply <strong>START</strong> to opt back in (verification may be required). Reply <strong>HELP</strong> for assistance.</p>
+<h2>Carrier Disclaimer</h2>
+<p>Carriers are not liable for delayed or undelivered messages.</p>
 <h2>Responsibilities</h2>
 <ul>
-  <li>Provide an accurate phone number.</li>
-  <li>Use STOP to opt out; HELP for assistance.</li>
+  <li>Provide an accurate phone number and keep your device secure.</li>
+  <li>Use the opt-out keywords to manage your preferences.</li>
 </ul>
 <h2>Liability</h2>
-<p>Alerts are informational only. We are not responsible for trading outcomes.</p>
+<p>Alerts are informational only and not financial advice. You are solely responsible for any trading decisions.</p>
 <h2>Changes</h2>
 <p>We may update these terms at this URL.</p>
 <h2>Contact</h2>

--- a/tests/test_sms_opt_in.py
+++ b/tests/test_sms_opt_in.py
@@ -28,13 +28,17 @@ def test_sms_verify_flow_records_consent(tmp_path, monkeypatch):
 
     res = client.post(
         "/api/sms/verify/start",
-        json={"phone": "(800) 555-1212", "consent_text": "I agree."},
+        json={
+            "phone": "(800) 555-1212",
+            "consent": True,
+            "consent_text": "I agree.",
+        },
         headers={"user-agent": "pytest"},
     )
     assert res.status_code == 200
     data = res.json()
     assert data["ok"]
-    assert data["phone"] == "+18005551212"
+    assert data["sent"] is True
 
     res = client.post(
         "/api/sms/verify/check",
@@ -76,7 +80,7 @@ def test_sms_reverify_creates_history(tmp_path, monkeypatch):
 
     client.post(
         "/api/sms/verify/start",
-        json={"phone": "+1 (800) 555-1212", "consent_text": "Consent"},
+        json={"phone": "+1 (800) 555-1212", "consent": True, "consent_text": "Consent"},
     )
     client.post(
         "/api/sms/verify/check",
@@ -85,7 +89,7 @@ def test_sms_reverify_creates_history(tmp_path, monkeypatch):
 
     client.post(
         "/api/sms/verify/start",
-        json={"phone": "800-555-1333", "consent_text": "Consent"},
+        json={"phone": "800-555-1333", "consent": True, "consent_text": "Consent"},
     )
     client.post(
         "/api/sms/verify/check",


### PR DESCRIPTION
## Summary
- update `/api/sms/verify/start` to handle JSON or form submissions, require consent, and send normalized verifications
- refresh the settings opt-in UI to validate phone input, surface inline errors, and show the new consent copy
- replace the Terms and Privacy templates with the latest compliance language and align tests with the new API contract

## Testing
- pytest tests/test_sms_opt_in.py

------
https://chatgpt.com/codex/tasks/task_e_68d2e4ce6ea08329876e64ba21e2ed63