### PR TITLE
Add debug simulation mode for favorites alerts

### DIFF
--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ class Settings:
     twilio_from_number: str = os.getenv("TWILIO_FROM_NUMBER", "")
     twilio_verify_service_sid: str = os.getenv("TWILIO_VERIFY_SERVICE_SID", "")
     alert_sms_to: Tuple[str, ...] = _csv("ALERT_SMS_TO")
-    alert_channel: str = _choice("ALERT_CHANNEL", "Email", allowed=("Email", "MMS"))
+    alert_channel: str = _choice("ALERT_CHANNEL", "Email", allowed=("Email", "MMS", "SMS"))
     alert_outcomes: str = _choice("ALERT_OUTCOMES", "hit", allowed=("hit", "all"))
     forward_recency_mode: str = _choice(
         "FORWARD_RECENCY_MODE", "off", allowed=("off", "exp")

--- a/db.py
+++ b/db.py
@@ -193,6 +193,7 @@ SCHEMA = [
         tt_bars INTEGER,
         dd REAL,
         rule_hash TEXT,
+        simulated INTEGER NOT NULL DEFAULT 0,
         PRIMARY KEY(favorite_id, entry_ts)
     );
     """,

--- a/scripts/clear_sim_data.py
+++ b/scripts/clear_sim_data.py
@@ -1,0 +1,68 @@
+"""Remove synthetic artifacts produced during DEBUG_SIMULATION runs."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from db import DB_PATH
+
+ALERTS_SQLITE = Path(__file__).resolve().parent.parent / "alerts.sqlite"
+EXPORT_FILES = [
+    Path(__file__).resolve().parent.parent / "sim_export.csv",
+    Path(__file__).resolve().parent.parent / "sim_export.json",
+]
+
+
+def _clear_forward_runs() -> int:
+    conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+    try:
+        cur = conn.cursor()
+        cur.execute("DELETE FROM forward_runs WHERE simulated=1")
+        deleted = cur.rowcount or 0
+        conn.commit()
+        return deleted
+    finally:
+        conn.close()
+
+
+def _clear_alert_dedupe() -> int:
+    if not ALERTS_SQLITE.exists():
+        return 0
+    conn = sqlite3.connect(ALERTS_SQLITE, check_same_thread=False)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute("DELETE FROM sent_alerts WHERE simulated=1")
+        except sqlite3.OperationalError:
+            return 0
+        deleted = cur.rowcount or 0
+        conn.commit()
+        return deleted
+    finally:
+        conn.close()
+
+
+def _remove_exports() -> list[Path]:
+    removed: list[Path] = []
+    for path in EXPORT_FILES:
+        try:
+            if path.exists():
+                path.unlink()
+                removed.append(path)
+        except OSError:
+            continue
+    return removed
+
+
+def main() -> None:
+    cleared_forward = _clear_forward_runs()
+    cleared_alerts = _clear_alert_dedupe()
+    removed = _remove_exports()
+    print(
+        f"Cleared {cleared_forward} forward runs, {cleared_alerts} alert dedupe records, "
+        f"removed {len(removed)} export files"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/config.py
+++ b/services/config.py
@@ -1,0 +1,8 @@
+"""Runtime flags for optional development helpers."""
+from __future__ import annotations
+
+import os
+
+DEBUG_SIMULATION: bool = os.getenv("DEBUG_SIMULATION", "0") == "1"
+
+__all__ = ["DEBUG_SIMULATION"]

--- a/services/scheduler.py
+++ b/services/scheduler.py
@@ -1,8 +1,62 @@
 """Lightweight scheduler utilities."""
 
-from datetime import datetime
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from services import market_calendar, scans
+from services.favorites_alerts import _dedupe_key as _fav_dedupe_key
+from services.favorites_alerts import mark_sent_key, was_sent_key
+
+
+logger = logging.getLogger(__name__)
+
+
+def _interval_to_minutes(interval: str | None) -> int:
+    if not interval:
+        return 15
+    value = str(interval).strip().lower()
+    if not value:
+        return 15
+    try:
+        if value.endswith("m"):
+            return max(1, int(float(value[:-1])))
+        if value.endswith("h"):
+            return max(1, int(float(value[:-1]) * 60))
+        if value.endswith("d"):
+            return max(1, int(float(value[:-1]) * 24 * 60))
+        return max(1, int(float(value)))
+    except (TypeError, ValueError):
+        return 15
+
+
+def _last_bar_close(now_utc: datetime, interval_minutes: int) -> datetime:
+    seconds = max(60, interval_minutes * 60)
+    epoch = int(now_utc.timestamp())
+    snapped = epoch - (epoch % seconds)
+    return datetime.fromtimestamp(snapped, tz=timezone.utc)
+
+
+def _is_bar_closed(now_utc: datetime, interval: str | None) -> bool:
+    minutes = _interval_to_minutes(interval)
+    last_close = _last_bar_close(now_utc, minutes)
+    return now_utc >= last_close + timedelta(seconds=10)
+
+
+def _align_to_bar(now_utc: datetime, interval: str | None) -> datetime:
+    minutes = _interval_to_minutes(interval)
+    return _last_bar_close(now_utc, minutes)
+
+
+def _dedupe_key(fav_id: Any, interval: Any, bar_dt_utc: Any, outcome: Any | None = None) -> str | None:
+    base = _fav_dedupe_key(fav_id, interval, bar_dt_utc)
+    if base and outcome not in (None, ""):
+        suffix = str(outcome).strip().lower()
+        if suffix:
+            return f"{base}|{suffix}"
+    return base
 
 
 def _tick(now: datetime) -> None:
@@ -10,8 +64,25 @@ def _tick(now: datetime) -> None:
 
     if not market_calendar.is_open(now):
         return
+    interval = "15m"
+    now_utc = now if now.tzinfo else now.replace(tzinfo=timezone.utc)
     if now.minute % 15 == 0 and now.second < 5:
+        aligned = _align_to_bar(now_utc, interval)
+        skipped_reason = None
+        if not _is_bar_closed(now_utc, interval):
+            skipped_reason = "bar_open"
+        logger.info(
+            "favorites_tick",
+            extra={
+                "bar_close": aligned.replace(microsecond=0).isoformat(),
+                "now": now_utc.replace(microsecond=0).isoformat(),
+                "grace_s": 10,
+                "skipped": skipped_reason,
+            },
+        )
+        if skipped_reason:
+            return
         scans.run_autoscan_batch()
 
 
-__all__ = ["_tick"]
+__all__ = ["_tick", "_align_to_bar", "_dedupe_key", "mark_sent_key", "was_sent_key"]

--- a/services/simulator.py
+++ b/services/simulator.py
@@ -1,0 +1,29 @@
+"""Helpers for building synthetic favorites events in development."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(slots=True)
+class SimEvent:
+    symbol: str
+    direction: str
+    outcome: str
+    bar_ts: datetime
+    note: str = "simulated"
+
+
+def _normalize(symbol: str) -> str:
+    return (symbol or "").upper()
+
+
+def build_sim_hit(symbol: str, direction: str, bar_ts: datetime) -> SimEvent:
+    return SimEvent(symbol=_normalize(symbol), direction=(direction or "UP").upper(), outcome="hit", bar_ts=bar_ts)
+
+
+def build_sim_stop(symbol: str, direction: str, bar_ts: datetime) -> SimEvent:
+    return SimEvent(symbol=_normalize(symbol), direction=(direction or "UP").upper(), outcome="stop", bar_ts=bar_ts)
+
+
+__all__ = ["SimEvent", "build_sim_hit", "build_sim_stop"]

--- a/templates/forward.html
+++ b/templates/forward.html
@@ -39,7 +39,7 @@
       <tbody id="forward-tbody"></tbody>
     </table>
   </div>
-  <div id="forward-history-modal" class="forward-history-modal" hidden>
+  <div id="forward-history-modal" class="forward-history-modal" hidden data-testid="history-modal">
       <div class="forward-history-dialog" role="dialog" aria-modal="true" aria-labelledby="forward-history-title">
         <div class="forward-history-header">
           <h2 id="forward-history-title">Forward Runs</h2>

--- a/templates/heatmap.html
+++ b/templates/heatmap.html
@@ -4,19 +4,21 @@
   <link rel="stylesheet" href="{{ url_for('static', path='css/heatmap.css') }}">
 {% endblock %}
 {% block content %}
-  <div class="card heatmap-card">
-    <div class="heatmap-header">
-      <div>
-        <h1 class="heatmap-title">Heatmap</h1>
-        <div class="heatmap-note">Sector × Ticker — Hit LB% (min support ≥ 10)</div>
+  <div class="card">
+    <div class="card-body">
+      <div class="card-title">Heatmap</div>
+      <p class="muted">Sector × Ticker — Hit LB% (min support ≥ 10)</p>
+      <div id="heatmap-message" class="muted" hidden>Loading heatmap…</div>
+      <div id="heatmap-empty" class="forward-empty-card" hidden>
+        <strong>No cells yet — run a scan or lower min support.</strong>
+        <p class="muted">Once scans complete, the heatmap will populate with the strongest sectors.</p>
       </div>
-    </div>
-    <div id="heatmap-message" class="heatmap-message" hidden>Loading heatmap…</div>
-    <div class="table-scroll" id="heatmap-table-container" hidden>
-      <table class="table table-compact table-hover heatmap-table" id="heatmap-table">
-        <thead></thead>
-        <tbody></tbody>
-      </table>
+      <div class="table-scroll" id="heatmap-table-container" hidden>
+        <table class="table table-compact table-hover" id="heatmap-table">
+          <thead></thead>
+          <tbody></tbody>
+        </table>
+      </div>
     </div>
   </div>
 {% endblock %}
@@ -28,6 +30,7 @@
     const tbody = table.querySelector('tbody');
     const container = document.getElementById('heatmap-table-container');
     const message = document.getElementById('heatmap-message');
+    const emptyCard = document.getElementById('heatmap-empty');
 
     function hexToRgb(hex){
       if(typeof hex !== 'string'){ return null; }
@@ -66,11 +69,19 @@
       message.textContent = text;
       message.hidden = false;
       container.hidden = true;
+      if(emptyCard){ emptyCard.hidden = true; }
     }
 
     function showTable(){
       message.hidden = true;
+      if(emptyCard){ emptyCard.hidden = true; }
       container.hidden = false;
+    }
+
+    function showEmpty(){
+      if(emptyCard){ emptyCard.hidden = false; }
+      message.hidden = true;
+      container.hidden = true;
     }
 
     function formatPercent(value, decimals){
@@ -88,7 +99,7 @@
       const meta = (data && typeof data.meta === 'object' && data.meta) ? data.meta : {};
 
       if(columns.length === 0 || index.length === 0){
-        showMessage('No heatmap data available.');
+        showEmpty();
         return;
       }
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -230,27 +230,32 @@
   <div class="card" style="margin-top:1rem;">
     <div class="card-body">
       <strong>Favorites Alerts</strong>
-      <div class="grid" style="margin-top:.5rem;">
+      <form id="test-alert-form" class="grid" style="margin-top:.5rem;" method="post">
         <div>
           <label>Symbol</label>
-          <input id="fav_symbol" value="AAPL" />
+          <input id="fav_symbol" name="symbol" value="AAPL" />
         </div>
         <div>
           <label>Channel</label>
-          <select id="test_channel">
-            <option value="Email" {% if alert_channel == 'Email' %}selected{% endif %}>Email</option>
-            <option value="MMS" {% if alert_channel == 'MMS' %}selected{% endif %}>MMS</option>
+          {% set selected_channel = (alert_channel or 'email')|lower %}
+          <select id="test_channel" name="channel">
+            <option value="email" {% if selected_channel == 'email' %}selected{% endif %}>Email</option>
+            <option value="mms" {% if selected_channel == 'mms' %}selected{% endif %}>MMS</option>
+            <option value="sms" {% if selected_channel == 'sms' %}selected{% endif %}>SMS</option>
           </select>
         </div>
         <div>
           <label>Outcomes</label>
-          <select id="test_outcomes">
-            <option value="hit" {% if alert_outcomes == 'hit' %}selected{% endif %}>Hit only</option>
-            <option value="all" {% if alert_outcomes == 'all' %}selected{% endif %}>Hit + Stop + Timeout</option>
+          {% set selected_outcomes = (alert_outcomes or 'hit')|lower %}
+          <select id="test_outcomes" name="outcomes">
+            <option value="hit" {% if selected_outcomes == 'hit' %}selected{% endif %}>Hit only</option>
+            <option value="all" {% if selected_outcomes == 'all' %}selected{% endif %}>Hit + Stop + Timeout</option>
           </select>
         </div>
-      </div>
-      <button id="send_test_alert" class="btn" style="margin-top:.75rem;">Send Test Alert</button>
+        <div style="grid-column: 1 / -1;">
+          <button id="send_test_alert" class="btn" type="submit" style="margin-top:.75rem;">Send Test Alert</button>
+        </div>
+      </form>
     </div>
   </div>
   <div id="sms-code-modal" hidden>
@@ -280,6 +285,7 @@
     }
 
     const sendBtn = document.getElementById('send_test_alert');
+    const testForm = document.getElementById('test-alert-form');
     const symbolInput = document.getElementById('fav_symbol');
     const channelSelect = document.getElementById('test_channel');
     const outcomesSelect = document.getElementById('test_outcomes');
@@ -399,7 +405,8 @@
       updateSmsButtonState();
     });
 
-    sendBtn?.addEventListener('click', async () => {
+    testForm?.addEventListener('submit', async (event) => {
+      event.preventDefault();
       const symbol = (symbolInput?.value || '').trim().toUpperCase();
       if (!symbol) {
         showToast('Enter a symbol to send a test alert.', false);
@@ -407,15 +414,11 @@
       }
       sendBtn.disabled = true;
       try {
-        const payload = {
-          symbol,
-          channel: channelSelect?.value || 'Email',
-          outcomes: outcomesSelect?.value || 'hit',
-        };
+        const formData = new FormData(testForm);
+        formData.set('symbol', symbol);
         const res = await fetch('/settings/test-alert', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
+          body: formData,
         });
         const data = await res.json();
         if (!res.ok || !data?.ok) {

--- a/tests/test_simulate_alert.py
+++ b/tests/test_simulate_alert.py
@@ -1,0 +1,141 @@
+import json
+import sqlite3
+from pathlib import Path
+
+import db
+import routes
+import scanner
+from fastapi import FastAPI
+from services import config as services_config
+from services import favorites_alerts
+from starlette.testclient import TestClient
+
+
+def setup_sim_app(tmp_path, monkeypatch):
+    db.DB_PATH = str(tmp_path / "sim.db")
+    db.init_db()
+    app = FastAPI()
+    app.include_router(routes.router)
+    client = TestClient(app)
+    monkeypatch.setattr(routes, "DEBUG_SIMULATION", True)
+    monkeypatch.setattr(scanner, "DEBUG_SIMULATION", True)
+    monkeypatch.setattr(services_config, "DEBUG_SIMULATION", True)
+    return client
+
+
+def test_simulate_alert_flow(tmp_path, monkeypatch):
+    client = setup_sim_app(tmp_path, monkeypatch)
+    alerts_db = Path("alerts.sqlite")
+    if alerts_db.exists():
+        alerts_db.unlink()
+
+    sent_payloads = []
+
+    def fake_send_email(host, port, user, password, mail_from, recipients, subject, body, context=None):
+        sent_payloads.append({
+            "host": host,
+            "port": port,
+            "mail_from": mail_from,
+            "recipients": recipients,
+            "subject": subject,
+            "body": body,
+            "context": context,
+        })
+        return {"ok": True}
+
+    monkeypatch.setattr(favorites_alerts, "send_email_smtp", fake_send_email)
+    monkeypatch.setattr(routes.twilio_client, "is_enabled", lambda: False)
+
+    payload = {
+        "symbol": "AAPL",
+        "direction": "DOWN",
+        "channel": "mms",
+        "outcome": "hit",
+        "outcomes_mode": "hit",
+        "bar_ts": "2025-09-17T13:45:00+00:00",
+        "recipients": ["alerts@example.com"],
+        "smtp": {
+            "host": "smtp.test",
+            "port": 2525,
+            "user": "alerts",
+            "password": "secret",
+            "mail_from": "alerts@example.com",
+        },
+    }
+
+    res = client.post("/debug/simulate", json=payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["was_sent"] is False
+    assert data["delivery"]["channel"] == "email"
+    assert data["delivery"]["reason"] == "sent"
+    assert sent_payloads and "[Sent via Email — MMS unavailable]" in sent_payloads[-1]["body"]
+
+    res_again = client.post("/debug/simulate", json=payload)
+    assert res_again.status_code == 200
+    data_again = res_again.json()
+    assert data_again["was_sent"] is True
+    assert "delivery" not in data_again
+
+    csv_path = Path("sim_export.csv")
+    json_path = Path("sim_export.json")
+    assert csv_path.exists()
+    assert json_path.exists()
+    export_rows = json.loads(json_path.read_text())
+    assert export_rows and export_rows[0]["symbol"] == "AAPL"
+
+    conn = sqlite3.connect(db.DB_PATH, check_same_thread=False)
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT favorite_id, simulated FROM forward_runs")
+        rows = cur.fetchall()
+    finally:
+        conn.close()
+    assert rows and rows[0][1] == 1
+
+    if alerts_db.exists():
+        conn = sqlite3.connect(alerts_db, check_same_thread=False)
+        try:
+            cur = conn.cursor()
+            cur.execute("SELECT simulated FROM sent_alerts")
+            alert_rows = cur.fetchall()
+        finally:
+            conn.close()
+        assert any(row[0] == 1 for row in alert_rows)
+
+
+def test_simulate_sms_channel(tmp_path, monkeypatch):
+    client = setup_sim_app(tmp_path, monkeypatch)
+    monkeypatch.setattr(routes.twilio_client, "is_enabled", lambda: True)
+
+    sent_numbers: list[str] = []
+
+    def fake_send_mms(number, body, *, context=None):
+        sent_numbers.append(number)
+        return True
+
+    monkeypatch.setattr(routes.twilio_client, "send_mms", fake_send_mms)
+
+    payload = {
+        "symbol": "MSFT",
+        "direction": "UP",
+        "channel": "sms",
+        "outcome": "hit",
+        "outcomes_mode": "hit",
+        "bar_ts": "2025-09-17T14:00:00+00:00",
+        "recipients": ["alerts@example.com"],
+        "smtp": {
+            "host": "smtp.test",
+            "port": 2525,
+            "user": "alerts",
+            "password": "secret",
+            "mail_from": "alerts@example.com",
+        },
+    }
+
+    res = client.post("/debug/simulate", json=payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["delivery"]["channel"] in {"sms", "mms"}
+    if sent_numbers:
+        assert sent_numbers[0].startswith("+") or sent_numbers[0].isdigit()


### PR DESCRIPTION
## Summary
- add a DEBUG_SIMULATION flag, simulation helpers, and a cleanup script so synthetic alerts can be toggled on and purged safely
- extend favorites alert delivery, scheduler alignment, and forward-run storage to track simulated dispatches with structured logging and fallback handling
- expose a /debug/simulate endpoint that emits synthetic alerts, forward history, and scanner exports, along with coverage for the new workflows

## Testing
- pytest tests/test_favorites_test_alert.py
- pytest tests/test_simulate_alert.py

------
https://chatgpt.com/codex/tasks/task_e_68d2ff72e2b48329a94496cdda73f1e6