### PR TITLE
Fix favorites alert scheduling and delivery coverage

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -2926,17 +2926,25 @@ async def favorites_add(request: Request, db=Depends(get_db)):
 @router.post("/settings/test-alert")
 async def favorites_test_alert(
     request: Request,
-    payload: dict | None = Body(default=None),
     db=Depends(get_db),
 ):
+    content_type = request.headers.get("content-type", "")
     form_data: dict[str, Any] = {}
-    try:
-        form = await request.form()
-        form_data = {k: v for k, v in form.multi_items()}
-    except Exception:
-        form_data = {}
+    payload: dict[str, Any] = {}
 
-    payload = payload or {}
+    if "application/json" in content_type:
+        try:
+            parsed = await request.json()
+        except Exception:
+            parsed = None
+        if isinstance(parsed, Mapping):
+            payload = dict(parsed)
+    else:
+        try:
+            form = await request.form()
+            form_data = {k: v for k, v in form.multi_items()}
+        except Exception:
+            form_data = {}
     symbol_raw = (
         form_data.get("symbol")
         or payload.get("symbol")

--- a/services/scheduler.py
+++ b/services/scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Optional
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -39,10 +40,10 @@ def _last_bar_close(now_utc: datetime, interval_minutes: int) -> datetime:
     return datetime.fromtimestamp(snapped, tz=timezone.utc)
 
 
-def _is_bar_closed(now_utc: datetime, interval: str | None) -> bool:
+def _is_bar_closed(now_utc: datetime, interval: str | None) -> tuple[bool, datetime]:
     minutes = _interval_to_minutes(interval)
     last_close = _last_bar_close(now_utc, minutes)
-    return now_utc >= last_close + timedelta(seconds=10)
+    return now_utc >= last_close + timedelta(seconds=10), last_close
 
 
 def _align_to_bar(now_utc: datetime, interval: str | None) -> datetime:
@@ -59,6 +60,9 @@ def _dedupe_key(fav_id: Any, interval: Any, bar_dt_utc: Any, outcome: Any | None
     return base
 
 
+_LAST_TICK_BOUNDARY: Optional[datetime] = None
+
+
 def _tick(now: datetime) -> None:
     """Evaluate periodic jobs for the current ``now`` timestamp."""
 
@@ -66,23 +70,34 @@ def _tick(now: datetime) -> None:
         return
     interval = "15m"
     now_utc = now if now.tzinfo else now.replace(tzinfo=timezone.utc)
-    if now.minute % 15 == 0 and now.second < 5:
-        aligned = _align_to_bar(now_utc, interval)
-        skipped_reason = None
-        if not _is_bar_closed(now_utc, interval):
-            skipped_reason = "bar_open"
-        logger.info(
-            "favorites_tick",
-            extra={
-                "bar_close": aligned.replace(microsecond=0).isoformat(),
-                "now": now_utc.replace(microsecond=0).isoformat(),
-                "grace_s": 10,
-                "skipped": skipped_reason,
-            },
-        )
-        if skipped_reason:
-            return
-        scans.run_autoscan_batch()
+    global _LAST_TICK_BOUNDARY
+
+    if now.minute % 15 != 0:
+        return
+
+    bar_closed, last_close = _is_bar_closed(now_utc, interval)
+    skipped_reason = None
+
+    if not bar_closed:
+        skipped_reason = "bar_open"
+    elif _LAST_TICK_BOUNDARY == last_close:
+        skipped_reason = "already_processed"
+
+    logger.info(
+        "favorites_tick",
+        extra={
+            "bar_close": last_close.replace(microsecond=0).isoformat(),
+            "now": now_utc.replace(microsecond=0).isoformat(),
+            "grace_s": 10,
+            "skipped": skipped_reason,
+        },
+    )
+
+    if skipped_reason:
+        return
+
+    _LAST_TICK_BOUNDARY = last_close
+    scans.run_autoscan_batch()
 
 
 __all__ = ["_tick", "_align_to_bar", "_dedupe_key", "mark_sent_key", "was_sent_key"]

--- a/tests/test_favorites_alerts_dedupe.py
+++ b/tests/test_favorites_alerts_dedupe.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from services import favorites_alerts
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(favorites_alerts, "_SENT_ALERTS", {})
+    monkeypatch.setattr(favorites_alerts, "_SQLITE_CONN", None)
+    monkeypatch.setattr(favorites_alerts, "_SQLITE_PATH", tmp_path / "alerts.sqlite")
+    monkeypatch.setattr(favorites_alerts, "_REDIS_CLIENT", None)
+    monkeypatch.setattr(favorites_alerts, "_REDIS_READY", None)
+
+
+def test_dedupe_ttl_expiry(monkeypatch):
+    base_ts = 1_700_000_000
+
+    def fake_time():
+        return fake_time.current
+
+    fake_time.current = float(base_ts)
+
+    monkeypatch.setattr(favorites_alerts, "_now", lambda: fake_time())
+    monkeypatch.setattr(favorites_alerts, "_REDIS_TTL_SECONDS", 60)
+
+    key = favorites_alerts._dedupe_key("fav-1", "15m", datetime.now(timezone.utc))
+    assert key
+
+    assert favorites_alerts.was_sent_key("fav-1", "now", interval="15m", dedupe_key=key) is False
+    favorites_alerts.mark_sent_key("fav-1", "now", interval="15m", dedupe_key=key)
+
+    assert favorites_alerts.was_sent_key("fav-1", "now", interval="15m", dedupe_key=key) is True
+
+    fake_time.current = base_ts + 61
+    assert favorites_alerts.was_sent_key("fav-1", "now", interval="15m", dedupe_key=key) is False
+
+    favorites_alerts.mark_sent_key("fav-1", "later", interval="15m", dedupe_key=key)
+
+    fake_time.current = base_ts + 120
+    assert favorites_alerts.was_sent_key("fav-1", "later", interval="15m", dedupe_key=key) is True

--- a/tests/test_favorites_alerts_delivery.py
+++ b/tests/test_favorites_alerts_delivery.py
@@ -1,0 +1,160 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from services import favorites_alerts
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch, tmp_path):
+    monkeypatch.setattr(favorites_alerts, "_SENT_ALERTS", {})
+    monkeypatch.setattr(favorites_alerts, "_SQLITE_CONN", None)
+    monkeypatch.setattr(favorites_alerts, "_SQLITE_PATH", tmp_path / "alerts.sqlite")
+    monkeypatch.setattr(favorites_alerts, "_REDIS_CLIENT", None)
+    monkeypatch.setattr(favorites_alerts, "_REDIS_READY", None)
+
+
+@pytest.mark.parametrize(
+    "channel,outcome",
+    [
+        ("email", "hit"),
+        ("email", "all"),
+        ("mms", "hit"),
+        ("mms", "all"),
+        ("sms", "hit"),
+        ("sms", "all"),
+    ],
+)
+def test_deliver_preview_matrix(monkeypatch, channel, outcome):
+    email_calls = []
+    sms_calls = []
+
+    def fake_email(host, port, user, password, mail_from, to, subject, body, *, context=None):
+        email_calls.append((subject, body, tuple(to), context))
+        return {"ok": True, "provider": "smtp", "message_id": "<id>"}
+
+    monkeypatch.setattr(favorites_alerts, "send_email_smtp", fake_email)
+    monkeypatch.setattr(favorites_alerts.twilio_client, "is_enabled", lambda: True)
+    monkeypatch.setattr(
+        favorites_alerts.twilio_client,
+        "send_mms",
+        lambda number, body, *, context=None: sms_calls.append((number, body, context)) or True,
+    )
+    monkeypatch.setattr(
+        favorites_alerts.sms_consent,
+        "active_destinations",
+        lambda: [{"phone_e164": "+18005550001", "user_id": "user-1"}],
+    )
+    monkeypatch.setattr(
+        favorites_alerts.sms_consent,
+        "allow_sending",
+        lambda number: (True, {"user_id": "user-1"}),
+    )
+    monkeypatch.setattr(
+        favorites_alerts.sms_consent,
+        "record_delivery",
+        lambda *args, **kwargs: None,
+    )
+
+    subject = "Preview"
+    bodies = {"email": "Email", "mms": "MMS", "sms": "SMS"}
+    bar_time = datetime(2024, 1, 2, 14, 45, tzinfo=timezone.utc).isoformat()
+    dedupe_key = f"fav1|15m|{bar_time}|{channel}|{outcome}"
+
+    recipients = ["alerts@example.com"] if channel == "email" else None
+    smtp_config = {
+        "host": "smtp.gmail.com",
+        "port": 587,
+        "user": "alerts@example.com",
+        "password": "app-pass",
+        "mail_from": "Alerts <alerts@example.com>",
+    }
+
+    response = favorites_alerts.deliver_preview_alert(
+        subject,
+        bodies,
+        channel=channel,
+        favorite_id="fav1",
+        bar_time=bar_time,
+        interval="15m",
+        dedupe_key=dedupe_key,
+        simulated=True,
+        outcome=outcome,
+        symbol="AAPL",
+        direction="UP",
+        recipients=recipients,
+        smtp_config=smtp_config,
+    )
+
+    assert response["ok"] is True
+    assert response["channel"] == (channel if channel in {"email", "sms"} else "mms")
+    assert response["reason"] == "sent"
+
+    if channel == "email":
+        assert email_calls, "email send expected"
+        assert sms_calls == []
+    else:
+        assert sms_calls, "twilio send expected"
+
+    throttled = favorites_alerts.deliver_preview_alert(
+        subject,
+        bodies,
+        channel=channel,
+        favorite_id="fav1",
+        bar_time=bar_time,
+        interval="15m",
+        dedupe_key=dedupe_key,
+        simulated=True,
+        outcome=outcome,
+        symbol="AAPL",
+        direction="UP",
+        recipients=recipients,
+        smtp_config=smtp_config,
+    )
+
+    assert throttled["ok"] is False
+    assert throttled["reason"] == "throttled"
+
+
+def test_deliver_preview_fallback_to_email(monkeypatch):
+    email_calls = []
+
+    def fake_email(host, port, user, password, mail_from, to, subject, body, *, context=None):
+        email_calls.append((subject, body, tuple(to), context))
+        return {"ok": True, "provider": "smtp", "message_id": "<fallback>"}
+
+    monkeypatch.setattr(favorites_alerts, "send_email_smtp", fake_email)
+    monkeypatch.setattr(favorites_alerts.twilio_client, "is_enabled", lambda: False)
+
+    subject = "Preview"
+    bodies = {"email": "Email", "mms": "MMS", "sms": "SMS"}
+    bar_time = datetime(2024, 1, 2, 14, 45, tzinfo=timezone.utc).isoformat()
+
+    smtp_config = {
+        "host": "smtp.gmail.com",
+        "port": 587,
+        "user": "alerts@example.com",
+        "password": "app-pass",
+        "mail_from": "Alerts <alerts@example.com>",
+    }
+
+    response = favorites_alerts.deliver_preview_alert(
+        subject,
+        bodies,
+        channel="mms",
+        favorite_id="fav2",
+        bar_time=bar_time,
+        interval="15m",
+        dedupe_key="fav2|15m|fallback",
+        simulated=True,
+        outcome="hit",
+        symbol="MSFT",
+        direction="DOWN",
+        recipients=["alerts@example.com"],
+        smtp_config=smtp_config,
+    )
+
+    assert response["ok"] is True
+    assert response["channel"] == "email"
+    assert response["reason"] == "sent"
+    assert email_calls and "[Sent via Email" in email_calls[0][1]

--- a/tests/test_scheduler_favorites.py
+++ b/tests/test_scheduler_favorites.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from services import scheduler
+
+
+@pytest.fixture(autouse=True)
+def _reset_globals(monkeypatch):
+    monkeypatch.setattr(scheduler, "_LAST_TICK_BOUNDARY", None)
+
+
+def test_tick_runs_once_per_bar(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(scheduler.market_calendar, "is_open", lambda now: True)
+    monkeypatch.setattr(
+        scheduler.scans,
+        "run_autoscan_batch",
+        lambda: calls.append("run"),
+    )
+
+    base = datetime(2024, 1, 2, 14, 45, tzinfo=timezone.utc)
+
+    scheduler._tick(base.replace(second=4))
+    scheduler._tick(base.replace(second=11))
+    scheduler._tick(base.replace(second=30))
+    scheduler._tick(base.replace(second=50))
+
+    next_bar = base.replace(minute=0, hour=15)
+    scheduler._tick(next_bar.replace(second=9))
+    scheduler._tick(next_bar.replace(second=12))
+
+    assert calls == ["run", "run"]


### PR DESCRIPTION
## Summary
- ensure the favorites scheduler waits for the bar-close grace window and only triggers once per interval
- enforce alert dedupe TTL across in-memory/sqlite storage, add delivery logging, and accept favorites test alerts posted from the settings form
- add regression tests covering scheduler timing, delivery channel matrix, dedupe expiry, form submissions, and Twilio fallbacks

## Testing
- pytest tests/test_favorites_alerts_delivery.py tests/test_favorites_alerts_dedupe.py tests/test_scheduler_favorites.py tests/test_favorites_test_alert.py

------
https://chatgpt.com/codex/tasks/task_e_68d6c95ee15c8329b09857e835b5f93b