### PR TITLE
Harden paper trading migration, engine, and UI

### DIFF
--- a/alembic/versions/0009_paper_trading.py
+++ b/alembic/versions/0009_paper_trading.py
@@ -1,0 +1,105 @@
+"""Paper trading tables
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2024-11-01 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    if not inspector.has_table("paper_settings"):
+        op.create_table(
+            "paper_settings",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("starting_balance", sa.Float, nullable=False, server_default="10000"),
+            sa.Column("max_pct", sa.Float, nullable=False, server_default="10"),
+            sa.Column("started_at", sa.Text, nullable=True),
+            sa.Column("status", sa.Text, nullable=False, server_default="inactive"),
+            sa.CheckConstraint("id = 1"),
+        )
+    else:
+        settings_cols = {col["name"] for col in inspector.get_columns("paper_settings")}
+        if "started_at" not in settings_cols:
+            op.add_column("paper_settings", sa.Column("started_at", sa.Text))
+        if "status" not in settings_cols:
+            op.add_column("paper_settings", sa.Column("status", sa.Text, server_default="inactive"))
+
+    op.execute(
+        """
+        INSERT OR IGNORE INTO paper_settings(id, starting_balance, max_pct, started_at, status)
+        VALUES(1, 10000, 10, NULL, 'inactive')
+        """
+    )
+
+    if not inspector.has_table("paper_equity"):
+        op.create_table(
+            "paper_equity",
+            sa.Column("ts", sa.Text, primary_key=True),
+            sa.Column("balance", sa.Float, nullable=False),
+        )
+
+    if not inspector.has_table("paper_trades"):
+        op.create_table(
+            "paper_trades",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("ticker", sa.Text, nullable=False),
+            sa.Column("call_put", sa.Text, nullable=False),
+            sa.Column("strike", sa.Float, nullable=True),
+            sa.Column("expiry", sa.Text, nullable=True),
+            sa.Column("qty", sa.Integer, nullable=False),
+            sa.Column("interval", sa.Text, nullable=True),
+            sa.Column("entry_time", sa.Text, nullable=False),
+            sa.Column("executed_at", sa.Text, nullable=False),
+            sa.Column("entry_price", sa.Float, nullable=False),
+            sa.Column("exit_time", sa.Text, nullable=True),
+            sa.Column("exit_price", sa.Float, nullable=True),
+            sa.Column("roi_pct", sa.Float, nullable=True),
+            sa.Column("status", sa.Text, nullable=False),
+            sa.Column("source_alert_id", sa.Text, nullable=True),
+            sa.Column("price_source", sa.Text, nullable=True),
+        )
+    else:
+        trade_cols = {col["name"] for col in inspector.get_columns("paper_trades")}
+        if "interval" not in trade_cols:
+            op.add_column("paper_trades", sa.Column("interval", sa.Text))
+        if "executed_at" not in trade_cols:
+            op.add_column("paper_trades", sa.Column("executed_at", sa.Text))
+            op.execute("UPDATE paper_trades SET executed_at = entry_time WHERE executed_at IS NULL")
+        if "status" not in trade_cols:
+            op.add_column("paper_trades", sa.Column("status", sa.Text, server_default="open"))
+
+    op.execute("CREATE INDEX IF NOT EXISTS ix_paper_trades_status ON paper_trades(status)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_paper_trades_ticker ON paper_trades(ticker)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_paper_trades_executed_at ON paper_trades(executed_at)")
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_paper_trades_source_alert
+        ON paper_trades(source_alert_id) WHERE source_alert_id IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_paper_trades_source_alert")
+    op.execute("DROP INDEX IF EXISTS ix_paper_trades_executed_at")
+    op.execute("DROP INDEX IF EXISTS ix_paper_trades_ticker")
+    op.execute("DROP INDEX IF EXISTS ix_paper_trades_status")
+    if inspect(op.get_bind()).has_table("paper_trades"):
+        op.drop_table("paper_trades")
+    if inspect(op.get_bind()).has_table("paper_equity"):
+        op.drop_table("paper_equity")
+    if inspect(op.get_bind()).has_table("paper_settings"):
+        op.drop_table("paper_settings")

--- a/db.py
+++ b/db.py
@@ -307,6 +307,49 @@ SCHEMA = [
     );
     """,
     "CREATE INDEX IF NOT EXISTS idx_oauth_tokens_created_at ON oauth_tokens(created_at);",
+    """
+    CREATE TABLE IF NOT EXISTS paper_settings (
+        id INTEGER PRIMARY KEY CHECK (id=1),
+        starting_balance REAL NOT NULL DEFAULT 10000,
+        max_pct REAL NOT NULL DEFAULT 10,
+        started_at TEXT,
+        status TEXT NOT NULL DEFAULT 'inactive'
+    );
+    """,
+    """
+    INSERT OR IGNORE INTO paper_settings(id, starting_balance, max_pct, started_at, status)
+    VALUES(1, 10000, 10, NULL, 'inactive');
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS paper_equity (
+        ts TEXT PRIMARY KEY,
+        balance REAL NOT NULL
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS paper_trades (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        ticker TEXT NOT NULL,
+        call_put TEXT NOT NULL,
+        strike REAL,
+        expiry TEXT,
+        qty INTEGER NOT NULL,
+        interval TEXT,
+        entry_time TEXT NOT NULL,
+        executed_at TEXT NOT NULL,
+        entry_price REAL NOT NULL,
+        exit_time TEXT,
+        exit_price REAL,
+        roi_pct REAL,
+        status TEXT NOT NULL,
+        source_alert_id TEXT,
+        price_source TEXT
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_paper_trades_status ON paper_trades(status);",
+    "CREATE INDEX IF NOT EXISTS idx_paper_trades_ticker ON paper_trades(ticker);",
+    "CREATE INDEX IF NOT EXISTS idx_paper_trades_executed_at ON paper_trades(executed_at);",
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_paper_trades_source_alert ON paper_trades(source_alert_id) WHERE source_alert_id IS NOT NULL;",
 ]
 
 

--- a/services/paper_trading.py
+++ b/services/paper_trading.py
@@ -1,0 +1,628 @@
+"""Paper trading engine, persistence helpers, and API utilities."""
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import math
+import os
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional, Sequence
+
+from utils import now_et
+
+logger = logging.getLogger(__name__)
+
+# Feature flag allowing deployments to disable real fills while testing.
+PAPER_DRY_RUN = os.getenv("PAPER_TRADING_DRY_RUN", "0").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+
+
+@dataclass(slots=True)
+class PaperSettings:
+    starting_balance: float
+    max_pct: float
+    status: str
+    started_at: str | None
+
+
+@dataclass(slots=True)
+class PaperTrade:
+    id: int
+    ticker: str
+    call_put: str
+    strike: float | None
+    expiry: str | None
+    qty: int
+    interval: str | None
+    entry_time: str
+    executed_at: str
+    entry_price: float
+    exit_time: str | None
+    exit_price: float | None
+    roi_pct: float | None
+    status: str
+    source_alert_id: str | None
+    price_source: str | None
+
+
+@dataclass(slots=True)
+class EquityPoint:
+    ts: str
+    balance: float
+
+
+def _now_utc_iso(dt: datetime | None = None) -> str:
+    current = dt or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    return current.astimezone(timezone.utc).isoformat()
+
+
+def ensure_settings(db) -> None:
+    db.execute(
+        """
+        INSERT OR IGNORE INTO paper_settings(id, starting_balance, max_pct, started_at, status)
+        VALUES(1, 10000, 10, NULL, 'inactive')
+        """
+    )
+    db.connection.commit()
+
+
+def load_settings(db) -> PaperSettings:
+    ensure_settings(db)
+    row = db.execute(
+        "SELECT starting_balance, max_pct, status, started_at FROM paper_settings WHERE id=1"
+    ).fetchone()
+    if not row:
+        return PaperSettings(10000.0, 10.0, "inactive", None)
+    return PaperSettings(
+        float(row["starting_balance"] or 0.0),
+        float(row["max_pct"] or 0.0),
+        str(row["status"] or "inactive"),
+        row["started_at"],
+    )
+
+
+def update_settings(db, *, starting_balance: float, max_pct: float) -> None:
+    ensure_settings(db)
+    start_value = max(0.0, float(starting_balance))
+    max_pct_value = max(0.0, min(float(max_pct), 100.0))
+    db.execute(
+        "UPDATE paper_settings SET starting_balance=?, max_pct=? WHERE id=1",
+        (start_value, max_pct_value),
+    )
+    db.connection.commit()
+
+
+def _seed_equity(db, settings: PaperSettings, *, now: datetime | None = None) -> None:
+    row = db.execute("SELECT COUNT(1) FROM paper_equity").fetchone()
+    count = int(row[0]) if row else 0
+    if count == 0:
+        ts = _now_utc_iso(now)
+        db.execute(
+            "INSERT OR REPLACE INTO paper_equity(ts, balance) VALUES(?, ?)",
+            (ts, float(settings.starting_balance)),
+        )
+        db.connection.commit()
+
+
+def _latest_balance(db, settings: PaperSettings | None = None) -> float:
+    row = db.execute(
+        "SELECT balance FROM paper_equity ORDER BY ts DESC LIMIT 1"
+    ).fetchone()
+    if row:
+        return float(row["balance"] or 0.0)
+    if settings is None:
+        settings = load_settings(db)
+    return float(settings.starting_balance)
+
+
+_CAP_EPSILON = 1e-6
+
+
+def calculate_max_contracts(balance: float, max_pct: float, option_price: float) -> tuple[int, float]:
+    pct = max(0.0, float(max_pct)) / 100.0
+    cap = max(0.0, float(balance)) * pct
+    cost_per_contract = max(0.0, float(option_price)) * 100.0
+    if cost_per_contract <= 0 or cap <= 0:
+        return 0, cap
+    raw_qty = cap / cost_per_contract
+    qty = int(math.floor(raw_qty + 1e-9))
+    while qty > 0 and (qty * cost_per_contract) - cap > _CAP_EPSILON:
+        qty -= 1
+    if qty < 0:
+        qty = 0
+    return qty, cap
+
+
+def calculate_roi(entry_price: float, exit_price: float) -> float:
+    entry = float(entry_price)
+    exit_val = float(exit_price)
+    if entry == 0:
+        return 0.0
+    return (exit_val - entry) / entry * 100.0
+
+
+def resolve_fill_price(
+    mid_price: float | None,
+    recent_mid: float | None,
+    underlying_move: float | None,
+    delta: float | None,
+) -> tuple[float, str]:
+    if mid_price is not None and mid_price > 0:
+        return float(mid_price), "mid"
+    if recent_mid is not None and recent_mid > 0:
+        return float(recent_mid), "recent_mid"
+    if underlying_move is not None and delta is not None:
+        magnitude = abs(float(underlying_move)) * max(abs(float(delta)), 0.01)
+        return max(0.01, round(magnitude, 2)), "synthetic_delta"
+    raise ValueError("Unable to determine option price for paper trade")
+
+
+def dedupe_key(ticker: str, call_put: str, interval: str | None) -> str:
+    parts = [str(ticker or "").upper(), str(call_put or "").upper()]
+    if interval:
+        parts.append(str(interval).lower())
+    return "|".join(parts)
+
+
+def _format_strike_exp_csv(strike: float | None, expiry: str | None) -> str:
+    if strike is None and not expiry:
+        return "—"
+    strike_text = "—"
+    if strike is not None:
+        strike_text = f"${strike:,.2f}".rstrip("0").rstrip(".")
+    expiry_text = "—"
+    if expiry:
+        try:
+            parsed = datetime.fromisoformat(str(expiry))
+        except ValueError:
+            expiry_text = str(expiry)
+        else:
+            expiry_text = parsed.strftime("%Y-%m-%d")
+    return f"{strike_text} — {expiry_text}"
+
+
+def _has_open_position(db, ticker: str, call_put: str, interval: str | None) -> bool:
+    ticker_key = ticker.upper()
+    direction = call_put.upper()
+    if interval:
+        row = db.execute(
+            """
+            SELECT id FROM paper_trades
+             WHERE status='open' AND ticker=? AND call_put=? AND interval=?
+             LIMIT 1
+            """,
+            (ticker_key, direction, interval.lower()),
+        ).fetchone()
+    else:
+        row = db.execute(
+            """
+            SELECT id FROM paper_trades
+             WHERE status='open' AND ticker=? AND call_put=? AND interval IS NULL
+             LIMIT 1
+            """,
+            (ticker_key, direction),
+        ).fetchone()
+    return bool(row)
+
+
+def _has_seen_alert(db, key: str | None) -> bool:
+    if not key:
+        return False
+    row = db.execute(
+        "SELECT id FROM paper_trades WHERE source_alert_id=? LIMIT 1",
+        (key,),
+    ).fetchone()
+    return bool(row)
+
+
+def _append_equity(db, balance: float, *, ts: datetime | None = None) -> None:
+    stamp = _now_utc_iso(ts)
+    db.execute(
+        "INSERT OR REPLACE INTO paper_equity(ts, balance) VALUES(?, ?)",
+        (stamp, float(balance)),
+    )
+    db.connection.commit()
+    logger.info(
+        "paper_equity_point",
+        extra={"balance": float(balance), "ts": stamp},
+    )
+
+
+def open_position(
+    db,
+    *,
+    ticker: str,
+    call_put: str,
+    strike: float | None,
+    expiry: str | None,
+    interval: str | None,
+    mid_price: float | None,
+    recent_mid: float | None,
+    underlying_move: float | None,
+    delta: float | None,
+    source_alert_id: str | None = None,
+    now: datetime | None = None,
+) -> Optional[int]:
+    settings = load_settings(db)
+    _seed_equity(db, settings, now=now)
+    if settings.status.lower() != "active":
+        logger.info(
+            "paper_trade_skipped",
+            extra={"symbol": ticker, "reason": "inactive", "key": source_alert_id},
+        )
+        return None
+    interval_norm = interval.lower() if interval else None
+    alert_key = (source_alert_id or "").strip() or None
+    dedupe_token = dedupe_key(ticker, call_put, interval)
+    if _has_seen_alert(db, alert_key):
+        logger.info(
+            "paper_trade_skipped",
+            extra={"symbol": ticker, "reason": "duplicate_alert", "key": alert_key},
+        )
+        return None
+    if _has_open_position(db, ticker, call_put, interval_norm):
+        logger.info(
+            "paper_trade_skipped",
+            extra={"symbol": ticker, "reason": "duplicate_open", "key": dedupe_token},
+        )
+        return None
+    if PAPER_DRY_RUN:
+        logger.info(
+            "paper_trade_skipped",
+            extra={"symbol": ticker, "reason": "dry_run", "key": dedupe_token},
+        )
+        return None
+    try:
+        price, price_source = resolve_fill_price(mid_price, recent_mid, underlying_move, delta)
+    except ValueError:
+        logger.info(
+            "paper_trade_skipped",
+            extra={"symbol": ticker, "reason": "no_price", "key": dedupe_token},
+        )
+        return None
+    balance = _latest_balance(db, settings)
+    qty, cap = calculate_max_contracts(balance, settings.max_pct, price)
+    if qty <= 0:
+        logger.info(
+            "paper_trade_skipped",
+            extra={
+                "symbol": ticker,
+                "reason": "insufficient_capital",
+                "cap": cap,
+                "price": price,
+            },
+        )
+        return None
+    cost = price * qty * 100.0
+    if cost - cap > _CAP_EPSILON:
+        max_affordable = int(math.floor((cap + _CAP_EPSILON) / (price * 100.0)))
+        while max_affordable > 0 and (price * max_affordable * 100.0) - cap > _CAP_EPSILON:
+            max_affordable -= 1
+        if max_affordable <= 0:
+            logger.info(
+                "paper_trade_skipped",
+                extra={
+                    "symbol": ticker,
+                    "reason": "insufficient_capital",
+                    "cap": cap,
+                    "price": price,
+                },
+            )
+            return None
+        qty = max_affordable
+        cost = price * qty * 100.0
+    entry_ts = _now_utc_iso(now or now_et())
+    executed_at = entry_ts
+    try:
+        db.execute(
+            """
+            INSERT INTO paper_trades(
+                ticker, call_put, strike, expiry, qty, interval, entry_time, executed_at, entry_price, status, source_alert_id, price_source
+            )
+            VALUES(?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                ticker.upper(),
+                call_put.upper(),
+                strike,
+                expiry,
+                qty,
+                interval_norm,
+                entry_ts,
+                executed_at,
+                price,
+                "open",
+                alert_key,
+                price_source,
+            ),
+        )
+    except sqlite3.IntegrityError:
+        logger.info(
+            "paper_trade_skipped",
+            extra={"symbol": ticker, "reason": "duplicate_alert", "key": alert_key or dedupe_token},
+        )
+        return None
+    except Exception as exc:
+        if "unique" in str(exc).lower():
+            logger.info(
+                "paper_trade_skipped",
+                extra={"symbol": ticker, "reason": "duplicate_alert", "key": alert_key or dedupe_token},
+            )
+            return None
+        raise
+    trade_id = int(db.lastrowid)
+    new_balance = balance - cost
+    _append_equity(db, new_balance, ts=now)
+    logger.info(
+        "paper_trade_opened",
+        extra={
+            "symbol": ticker.upper(),
+            "qty": qty,
+            "price": price,
+            "strike": strike,
+            "expiry": expiry,
+            "call_put": call_put.upper(),
+            "trade_id": trade_id,
+            "price_source": price_source,
+            "interval": interval_norm,
+        },
+    )
+    return trade_id
+
+
+def close_position(
+    db,
+    trade_id: int,
+    *,
+    exit_price: float,
+    reason: str,
+    now: datetime | None = None,
+) -> Optional[PaperTrade]:
+    row = db.execute(
+        "SELECT * FROM paper_trades WHERE id=? LIMIT 1",
+        (int(trade_id),),
+    ).fetchone()
+    if not row or str(row["status"]).lower() != "open":
+        return None
+    settings = load_settings(db)
+    balance = _latest_balance(db, settings)
+    qty = int(row["qty"])
+    entry_price = float(row["entry_price"])
+    roi = calculate_roi(entry_price, exit_price)
+    exit_ts = _now_utc_iso(now or now_et())
+    db.execute(
+        """
+        UPDATE paper_trades
+           SET status='closed', exit_time=?, exit_price=?, roi_pct=?
+         WHERE id=?
+        """,
+        (exit_ts, float(exit_price), roi, int(trade_id)),
+    )
+    proceeds = float(exit_price) * qty * 100.0
+    new_balance = balance + proceeds
+    _append_equity(db, new_balance, ts=now)
+    logger.info(
+        "paper_trade_closed",
+        extra={
+            "symbol": row["ticker"],
+            "qty": qty,
+            "price": exit_price,
+            "roi": roi,
+            "reason": reason,
+            "trade_id": trade_id,
+        },
+    )
+    return PaperTrade(
+        id=int(trade_id),
+        ticker=row["ticker"],
+        call_put=row["call_put"],
+        strike=row["strike"],
+        expiry=row["expiry"],
+        qty=qty,
+        interval=row["interval"],
+        entry_time=row["entry_time"],
+        executed_at=row["executed_at"],
+        entry_price=entry_price,
+        exit_time=exit_ts,
+        exit_price=float(exit_price),
+        roi_pct=roi,
+        status="closed",
+        source_alert_id=row["source_alert_id"],
+        price_source=row["price_source"],
+    )
+
+
+def start_engine(db, *, now: datetime | None = None) -> PaperSettings:
+    settings = load_settings(db)
+    if settings.status.lower() == "active":
+        _seed_equity(db, settings, now=now)
+        return settings
+    started_at = _now_utc_iso(now or now_et())
+    db.execute(
+        "UPDATE paper_settings SET status='active', started_at=? WHERE id=1",
+        (started_at,),
+    )
+    db.connection.commit()
+    _seed_equity(db, settings, now=now)
+    return load_settings(db)
+
+
+def stop_engine(db) -> PaperSettings:
+    db.execute(
+        "UPDATE paper_settings SET status='inactive' WHERE id=1"
+    )
+    db.connection.commit()
+    return load_settings(db)
+
+
+def restart_engine(db, *, now: datetime | None = None) -> PaperSettings:
+    settings = load_settings(db)
+    db.execute("DELETE FROM paper_trades")
+    db.execute("DELETE FROM paper_equity")
+    db.connection.commit()
+    _seed_equity(db, settings, now=now)
+    return start_engine(db, now=now)
+
+
+def get_summary(db) -> dict:
+    settings = load_settings(db)
+    _seed_equity(db, settings)
+    balance = _latest_balance(db, settings)
+    starting = float(settings.starting_balance) or 0.0
+    roi = calculate_roi(starting or 1.0, balance) if starting else 0.0
+    open_count = db.execute(
+        "SELECT COUNT(1) FROM paper_trades WHERE status='open'"
+    ).fetchone()[0]
+    return {
+        "balance": balance,
+        "starting_balance": starting,
+        "roi_pct": roi,
+        "status": settings.status,
+        "started_at": settings.started_at,
+        "open_trades": int(open_count),
+    }
+
+
+_RANGE_LOOKUPS = {
+    "1d": timedelta(days=1),
+    "1w": timedelta(weeks=1),
+    "1m": timedelta(days=30),
+    "1y": timedelta(days=365),
+}
+
+
+def get_equity_points(db, range_key: str) -> List[EquityPoint]:
+    settings = load_settings(db)
+    _seed_equity(db, settings)
+    range_key = (range_key or "1m").lower()
+    delta = _RANGE_LOOKUPS.get(range_key, _RANGE_LOOKUPS["1m"])
+    start_ts = datetime.now(timezone.utc) - delta
+    rows = db.execute(
+        "SELECT ts, balance FROM paper_equity WHERE ts >= ? ORDER BY ts",
+        (_now_utc_iso(start_ts),),
+    ).fetchall()
+    return [EquityPoint(ts=row["ts"], balance=float(row["balance"])) for row in rows]
+
+
+def _query_trades(db, status: str | None) -> Sequence[PaperTrade]:
+    params: list = []
+    sql = "SELECT * FROM paper_trades"
+    if status and status.lower() in {"open", "closed"}:
+        sql += " WHERE status=?"
+        params.append(status.lower())
+    sql += " ORDER BY entry_time DESC"
+    rows = db.execute(sql, tuple(params)).fetchall()
+    return [
+        PaperTrade(
+            id=int(row["id"]),
+            ticker=row["ticker"],
+            call_put=row["call_put"],
+            strike=row["strike"],
+            expiry=row["expiry"],
+            qty=int(row["qty"]),
+            interval=row["interval"],
+            entry_time=row["entry_time"],
+            executed_at=row["executed_at"],
+            entry_price=float(row["entry_price"]),
+            exit_time=row["exit_time"],
+            exit_price=float(row["exit_price"]) if row["exit_price"] is not None else None,
+            roi_pct=float(row["roi_pct"]) if row["roi_pct"] is not None else None,
+            status=row["status"],
+            source_alert_id=row["source_alert_id"],
+            price_source=row["price_source"],
+        )
+        for row in rows
+    ]
+
+
+def list_trades(db, status: str | None) -> List[dict]:
+    trades = _query_trades(db, status)
+    results: list[dict] = []
+    for trade in trades:
+        results.append(
+            {
+                "id": trade.id,
+                "ticker": trade.ticker,
+                "call_put": trade.call_put,
+                "strike": trade.strike,
+                "expiry": trade.expiry,
+                "qty": trade.qty,
+                "interval": trade.interval,
+                "entry_time": trade.entry_time,
+                "executed_at": trade.executed_at,
+                "entry_price": trade.entry_price,
+                "exit_time": trade.exit_time,
+                "exit_price": trade.exit_price,
+                "roi_pct": trade.roi_pct,
+                "status": trade.status,
+                "price_source": trade.price_source,
+            }
+        )
+    return results
+
+
+def export_trades_csv(db, status: str | None) -> tuple[str, str]:
+    trades = _query_trades(db, status)
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(
+        [
+            "Ticker",
+            "Call/Put",
+            "Strike–Expiry",
+            "Quantity",
+            "Entry Time & Date",
+            "Entry Price",
+            "Exit Time & Date",
+            "Exit Price",
+            "ROI%",
+            "Status",
+        ]
+    )
+    for trade in trades:
+        writer.writerow(
+            [
+                trade.ticker,
+                trade.call_put,
+                _format_strike_exp_csv(trade.strike, trade.expiry),
+                trade.qty,
+                trade.entry_time,
+                f"{trade.entry_price:.2f}",
+                trade.exit_time or "",
+                f"{trade.exit_price:.2f}" if trade.exit_price is not None else "",
+                f"{trade.roi_pct:.2f}" if trade.roi_pct is not None else "",
+                trade.status,
+            ]
+        )
+    return buffer.getvalue(), "paper_trades.csv"
+
+
+__all__ = [
+    "PaperSettings",
+    "PaperTrade",
+    "EquityPoint",
+    "calculate_max_contracts",
+    "calculate_roi",
+    "resolve_fill_price",
+    "dedupe_key",
+    "open_position",
+    "close_position",
+    "start_engine",
+    "stop_engine",
+    "restart_engine",
+    "get_summary",
+    "get_equity_points",
+    "list_trades",
+    "export_trades_csv",
+    "update_settings",
+    "load_settings",
+]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -973,3 +973,191 @@ select:focus,
 .site-footer a:focus {
   text-decoration:underline;
 }
+
+.paper-container {
+  display:flex;
+  flex-direction:column;
+  gap:1.5rem;
+}
+
+.paper-header-card {
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
+}
+
+.paper-header-top {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:1rem;
+  flex-wrap:wrap;
+}
+
+.paper-label {
+  margin:0;
+  color:var(--muted);
+  font-size:0.95rem;
+}
+
+#paper-balance {
+  font-size:2.5rem;
+  font-weight:600;
+  letter-spacing:0.01em;
+}
+
+.paper-roi-chip {
+  border-radius:999px;
+  padding:0.35rem 0.75rem;
+  font-weight:600;
+  background:rgba(61,220,132,0.15);
+  color:var(--pos);
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-width:5rem;
+  text-align:center;
+}
+
+.paper-roi-chip.chip-pos {
+  background:rgba(61,220,132,0.15);
+  color:var(--pos);
+}
+
+.paper-roi-chip.chip-neg {
+  background:rgba(255,77,77,0.18);
+  color:var(--neg);
+}
+
+.paper-header-bottom {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  flex-wrap:wrap;
+  gap:1rem;
+}
+
+.paper-range-toggle {
+  display:inline-flex;
+  gap:0.35rem;
+  padding:0.25rem;
+  background:rgba(94,160,255,0.12);
+  border-radius:999px;
+}
+
+.paper-range-btn {
+  border:none;
+  background:transparent;
+  color:var(--muted);
+  padding:0.35rem 0.75rem;
+  border-radius:999px;
+  font-weight:600;
+  cursor:pointer;
+  transition:background 0.2s ease, color 0.2s ease;
+}
+
+.paper-range-btn:hover,
+.paper-range-btn:focus {
+  color:var(--text);
+}
+
+.paper-range-btn.is-active {
+  background:var(--accent);
+  color:#06121f;
+}
+
+.paper-status-line {
+  color:var(--muted);
+  font-size:0.95rem;
+}
+
+.paper-chart-wrapper {
+  background:linear-gradient(180deg, rgba(94,160,255,0.12), rgba(14,17,22,0));
+  border-radius:12px;
+  padding:1rem;
+  border:1px solid rgba(94,160,255,0.15);
+}
+
+#paper-equity-chart {
+  width:100%;
+  display:block;
+}
+
+.paper-table-card {
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
+}
+
+.paper-table-toolbar {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:1rem;
+  flex-wrap:wrap;
+}
+
+.paper-table-title {
+  margin:0;
+}
+
+.paper-table-scroll {
+  max-height:500px;
+  overflow:auto;
+  border-radius:12px;
+  border:1px solid rgba(255,255,255,0.05);
+}
+
+.paper-table {
+  width:100%;
+  border-collapse:collapse;
+}
+
+.paper-table thead th {
+  position:sticky;
+  top:0;
+  background:rgba(8,12,18,0.95);
+  backdrop-filter:blur(6px);
+  z-index:2;
+}
+
+.paper-roi-pos {
+  color:var(--pos);
+}
+
+.paper-roi-neg {
+  color:var(--neg);
+}
+
+@media (max-width: 768px) {
+  #paper-balance {
+    font-size:2rem;
+  }
+  .paper-table-scroll {
+    max-height:360px;
+  }
+  .paper-range-toggle {
+    width:100%;
+    justify-content:space-between;
+  }
+}
+
+#paper-chart-tooltip {
+  position:fixed;
+  pointer-events:none;
+  background:rgba(8,12,18,0.92);
+  border:1px solid rgba(94,160,255,0.4);
+  color:var(--text);
+  padding:0.45rem 0.6rem;
+  border-radius:8px;
+  font-size:0.85rem;
+  box-shadow:0 8px 24px rgba(0,0,0,0.35);
+  display:none;
+  z-index:999;
+  min-width:180px;
+}
+
+#paper-chart-tooltip strong {
+  display:block;
+  margin-bottom:0.25rem;
+}

--- a/static/js/paper.js
+++ b/static/js/paper.js
@@ -1,0 +1,324 @@
+(function(){
+  const summarySeedEl = document.getElementById('paper-summary-seed');
+  let summarySeed = {};
+  if (summarySeedEl) {
+    try {
+      summarySeed = JSON.parse(summarySeedEl.textContent || '{}') || {};
+    } catch (err) {
+      summarySeed = {};
+    }
+  }
+
+  const balanceEl = document.getElementById('paper-balance');
+  const roiChip = document.getElementById('paper-roi-chip');
+  const statusLine = document.getElementById('paper-status-line');
+  const rangeButtons = Array.from(document.querySelectorAll('.paper-range-btn'));
+  const tableBody = document.getElementById('paper-trades-body');
+  const canvas = document.getElementById('paper-equity-chart');
+  const tooltip = document.createElement('div');
+  tooltip.id = 'paper-chart-tooltip';
+  document.body.appendChild(tooltip);
+
+  const currencyFmt = new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' });
+  const percentFmt = new Intl.NumberFormat(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  const dateTimeFmt = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+  const dateShortFmt = new Intl.DateTimeFormat(undefined, { month: 'numeric', day: 'numeric' });
+
+  let currentRange = '1m';
+  let chartState = { points: [], baseBalance: 0, rendered: false };
+
+  function formatCurrency(value) {
+    const num = Number(value) || 0;
+    return currencyFmt.format(num);
+  }
+
+  function formatPercent(value) {
+    const num = Number(value) || 0;
+    return `${percentFmt.format(num)}%`;
+  }
+
+  function applySummary(data) {
+    if (!data) return;
+    const balance = Number(data.balance) || 0;
+    const roi = Number(data.roi_pct) || 0;
+    if (balanceEl) {
+      balanceEl.dataset.balance = String(balance);
+      balanceEl.textContent = formatCurrency(balance);
+    }
+    if (roiChip) {
+      roiChip.textContent = formatPercent(roi);
+      roiChip.classList.remove('chip-neg', 'chip-pos');
+      roiChip.classList.add(roi < 0 ? 'chip-neg' : 'chip-pos');
+    }
+    if (statusLine) {
+      const status = (data.status || '').toLowerCase();
+      const startedRaw = data.started_at;
+      let startedLabel = startedRaw;
+      if (startedRaw) {
+        const parsed = new Date(startedRaw);
+        if (!Number.isNaN(parsed.valueOf())) {
+          startedLabel = dateTimeFmt.format(parsed);
+        }
+      }
+      if (status === 'active' && startedLabel) {
+        statusLine.textContent = `Active and running since ${startedLabel}`;
+      } else if (status === 'active') {
+        statusLine.textContent = 'Active and running';
+      } else {
+        statusLine.textContent = 'Inactive';
+      }
+    }
+  }
+
+  function formatStrikeExp(strike, expiry) {
+    const strikeNum = Number(strike);
+    const strikeText = Number.isFinite(strikeNum) ? `$${strikeNum.toFixed(2).replace(/\.00$/, '')}` : '—';
+    if (!expiry) {
+      return `${strikeText}–—`;
+    }
+    const asDate = new Date(expiry);
+    if (!Number.isNaN(asDate.valueOf())) {
+      return `${strikeText}–${dateShortFmt.format(asDate)}`;
+    }
+    return `${strikeText}–${expiry}`;
+  }
+
+  function formatDateCell(value) {
+    if (!value) {
+      return { text: '—', title: '' };
+    }
+    const dt = new Date(value);
+    if (Number.isNaN(dt.valueOf())) {
+      return { text: value, title: value };
+    }
+    return { text: dateTimeFmt.format(dt), title: dt.toISOString() };
+  }
+
+  function renderTrades(rows) {
+    if (!tableBody) return;
+    const items = Array.isArray(rows) ? rows : [];
+    if (!items.length) {
+      tableBody.innerHTML = '<tr><td colspan="10" class="muted">No paper trades yet.</td></tr>';
+      return;
+    }
+    const frag = document.createDocumentFragment();
+    items.forEach((row) => {
+      const tr = document.createElement('tr');
+      const entryMeta = formatDateCell(row.entry_time);
+      const exitMeta = formatDateCell(row.exit_time);
+      const roi = Number(row.roi_pct);
+      const roiCell = document.createElement('td');
+      if (Number.isFinite(roi)) {
+        roiCell.textContent = `${percentFmt.format(roi)}%`;
+        roiCell.className = roi >= 0 ? 'paper-roi-pos' : 'paper-roi-neg';
+      } else {
+        roiCell.textContent = '—';
+      }
+      const statusText = row.status ? String(row.status).replace(/\b\w/g, (c) => c.toUpperCase()) : '';
+
+      const cells = [
+        row.ticker || '—',
+        row.call_put || '—',
+        formatStrikeExp(row.strike, row.expiry),
+        Number(row.qty) || 0,
+        entryMeta,
+        row.entry_price != null ? formatCurrency(row.entry_price) : '—',
+        exitMeta,
+        row.exit_price != null ? formatCurrency(row.exit_price) : '—',
+        roiCell,
+        statusText || '—',
+      ];
+
+      cells.forEach((cell, idx) => {
+        let td;
+        if (cell instanceof HTMLElement) {
+          td = cell;
+        } else if (typeof cell === 'object' && cell && 'text' in cell) {
+          td = document.createElement('td');
+          td.textContent = cell.text;
+          if (cell.title) {
+            td.title = cell.title;
+          }
+        } else {
+          td = document.createElement('td');
+          td.textContent = String(cell);
+        }
+        tr.appendChild(td);
+      });
+
+      frag.appendChild(tr);
+    });
+    tableBody.innerHTML = '';
+    tableBody.appendChild(frag);
+  }
+
+  function renderChart(points) {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const deviceRatio = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    const width = rect.width || 600;
+    const height = rect.height || 260;
+    canvas.width = width * deviceRatio;
+    canvas.height = height * deviceRatio;
+    ctx.setTransform(deviceRatio, 0, 0, deviceRatio, 0, 0);
+    ctx.clearRect(0, 0, width, height);
+
+    const dataset = Array.isArray(points) ? points : [];
+    if (!dataset.length) {
+      chartState = { points: [], baseBalance: 0, rendered: false };
+      return;
+    }
+    const balances = dataset.map((d) => Number(d.balance) || 0);
+    const times = dataset.map((d) => new Date(d.ts));
+    const minBal = Math.min(...balances);
+    const maxBal = Math.max(...balances);
+    const minTime = Math.min(...times.map((d) => d.valueOf()));
+    const maxTime = Math.max(...times.map((d) => d.valueOf()));
+    const padX = 20;
+    const padY = 20;
+    const chartW = width - padX * 2;
+    const chartH = height - padY * 2;
+    const spanBal = Math.max(1e-6, maxBal - minBal);
+    const spanTime = Math.max(1e-6, maxTime - minTime);
+
+    const plotted = dataset.map((point, index) => {
+      const t = times[index].valueOf();
+      const value = balances[index];
+      const x = padX + ((t - minTime) / spanTime) * chartW;
+      const y = padY + (1 - (value - minBal) / spanBal) * chartH;
+      return { x, y, rawX: t, balance: value, ts: point.ts };
+    });
+
+    ctx.lineWidth = 2;
+    const gradient = ctx.createLinearGradient(0, padY, 0, height - padY);
+    gradient.addColorStop(0, 'rgba(94,160,255,0.7)');
+    gradient.addColorStop(1, 'rgba(94,160,255,0.1)');
+
+    ctx.beginPath();
+    plotted.forEach((pt, idx) => {
+      if (idx === 0) {
+        ctx.moveTo(pt.x, pt.y);
+      } else {
+        ctx.lineTo(pt.x, pt.y);
+      }
+    });
+    ctx.strokeStyle = '#5ea0ff';
+    ctx.stroke();
+
+    ctx.lineTo(plotted[plotted.length - 1].x, height - padY);
+    ctx.lineTo(plotted[0].x, height - padY);
+    ctx.closePath();
+    ctx.fillStyle = gradient;
+    ctx.fill();
+
+    chartState = {
+      points: plotted,
+      baseBalance: balances[0],
+      rendered: true,
+    };
+  }
+
+  function nearestPoint(canvasX) {
+    if (!chartState.rendered || !chartState.points.length) return null;
+    let best = chartState.points[0];
+    let bestDist = Math.abs(canvasX - best.x);
+    for (let i = 1; i < chartState.points.length; i += 1) {
+      const pt = chartState.points[i];
+      const dist = Math.abs(canvasX - pt.x);
+      if (dist < bestDist) {
+        best = pt;
+        bestDist = dist;
+      }
+    }
+    return best;
+  }
+
+  function showTooltip(pt, evt) {
+    if (!pt) return;
+    const base = chartState.baseBalance || 0;
+    const delta = pt.balance - base;
+    const pct = base === 0 ? 0 : (delta / base) * 100;
+    const dt = new Date(pt.ts);
+    const positionX = evt.clientX + 12;
+    const positionY = evt.clientY + 12;
+    tooltip.innerHTML = `
+      <strong>${Number.isNaN(dt.valueOf()) ? pt.ts : dateTimeFmt.format(dt)}</strong>
+      <div>Balance: ${formatCurrency(pt.balance)}</div>
+      <div>Range Δ: ${formatCurrency(delta)} (${percentFmt.format(pct)}%)</div>
+    `;
+    tooltip.style.left = `${positionX}px`;
+    tooltip.style.top = `${positionY}px`;
+    tooltip.style.display = 'block';
+  }
+
+  function hideTooltip() {
+    tooltip.style.display = 'none';
+  }
+
+  if (canvas) {
+    canvas.addEventListener('mousemove', (evt) => {
+      if (!chartState.rendered) return;
+      const rect = canvas.getBoundingClientRect();
+      const canvasX = evt.clientX - rect.left;
+      const pt = nearestPoint(canvasX);
+      if (pt) {
+        showTooltip(pt, evt);
+      } else {
+        hideTooltip();
+      }
+    });
+    canvas.addEventListener('mouseleave', hideTooltip);
+  }
+
+  function fetchSummary() {
+    return fetch('/paper/summary', { credentials: 'same-origin' })
+      .then((resp) => (resp.ok ? resp.json() : null))
+      .then((data) => {
+        if (data) {
+          applySummary(data);
+        }
+      })
+      .catch(() => {});
+  }
+
+  function fetchEquity(rangeKey) {
+    const key = rangeKey || currentRange;
+    return fetch(`/paper/equity?range=${encodeURIComponent(key)}`, { credentials: 'same-origin' })
+      .then((resp) => (resp.ok ? resp.json() : null))
+      .then((payload) => {
+        if (payload && Array.isArray(payload.points)) {
+          renderChart(payload.points);
+        }
+      })
+      .catch(() => {});
+  }
+
+  function fetchTrades() {
+    return fetch('/paper/trades?status=all', { credentials: 'same-origin' })
+      .then((resp) => (resp.ok ? resp.json() : null))
+      .then((payload) => {
+        if (payload && Array.isArray(payload.trades)) {
+          renderTrades(payload.trades);
+        }
+      })
+      .catch(() => {});
+  }
+
+  rangeButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const range = btn.dataset.range || '1m';
+      currentRange = range;
+      rangeButtons.forEach((el) => el.classList.toggle('is-active', el === btn));
+      fetchEquity(range);
+    });
+  });
+
+  if (summarySeed && Object.keys(summarySeed).length) {
+    applySummary(summarySeed);
+  }
+  fetchSummary();
+  fetchEquity(currentRange);
+  fetchTrades();
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,6 +25,7 @@
       <a class="nav-link {% if active_tab=='scanner' %}active{% endif %}" href="/scanner">Scanner</a>
       <a class="nav-link {% if active_tab=='favorites' %}active{% endif %}" href="/favorites">Favorites</a>
       <a class="nav-link {% if active_tab=='forward' %}active{% endif %}" href="/forward">Forward Test</a>
+      <a class="nav-link {% if active_tab=='paper' %}active{% endif %}" href="/paper">Paper</a>
       <a class="nav-link {% if active_tab=='heatmap' %}active{% endif %}" href="/heatmap">Heatmap</a>
       <a class="nav-link {% if active_tab=='archive' %}active{% endif %}" href="/archive">Archive</a>
       <a class="nav-link {% if active_tab=='overnight' %}active{% endif %}" href="/overnight">Overnight</a>

--- a/templates/paper.html
+++ b/templates/paper.html
@@ -1,0 +1,73 @@
+{% extends 'base.html' %}
+{% block title %}Paper Trading — Petra Stock{% endblock %}
+{% block content %}
+  <div class="paper-container">
+    <div class="card paper-header-card">
+      <div class="paper-header-top">
+        <div class="paper-balance-group">
+          <p class="paper-label">Account Total</p>
+          {% set balance_value = summary.balance or 0.0 %}
+          <div id="paper-balance" data-balance="{{ balance_value }}">
+            ${{ '{:,.2f}'.format(balance_value) }}
+          </div>
+        </div>
+        {% set roi_value = summary.roi_pct or 0.0 %}
+        <span id="paper-roi-chip" class="paper-roi-chip {% if roi_value >= 0 %}chip-pos{% else %}chip-neg{% endif %}">
+          {{ '%.2f'|format(roi_value) }}%
+        </span>
+      </div>
+      <div class="paper-header-bottom">
+        <div class="paper-range-toggle" role="group" aria-label="Equity range">
+          {% set default_range = '1m' %}
+          {% for key,label in {'1d':'1D','1w':'1W','1m':'1M','1y':'1Y'}.items() %}
+            <button type="button" class="paper-range-btn {% if key == default_range %}is-active{% endif %}" data-range="{{ key }}">{{ label }}</button>
+          {% endfor %}
+        </div>
+        <div id="paper-status-line" class="paper-status-line">
+          {% if summary.status == 'active' %}
+            {% if summary.started_at %}
+              Active and running since {{ summary.started_at }}
+            {% else %}
+              Active and running
+            {% endif %}
+          {% else %}
+            Inactive
+          {% endif %}
+        </div>
+      </div>
+      <div class="paper-chart-wrapper">
+        <canvas id="paper-equity-chart" height="260" aria-label="Paper trading equity chart"></canvas>
+      </div>
+    </div>
+
+    <div class="card paper-table-card">
+      <div class="paper-table-toolbar">
+        <h2 class="paper-table-title">Activity</h2>
+        <a id="paper-export" class="btn btn-secondary btn-sm" href="/paper/trades?status=all&export=csv">Export CSV</a>
+      </div>
+      <div class="paper-table-scroll">
+        <table id="paper-trades-table" class="table paper-table" aria-describedby="paper-status-line">
+          <thead>
+            <tr>
+              <th>Ticker</th>
+              <th>Call/Put</th>
+              <th>Strike–Exp</th>
+              <th>Qty</th>
+              <th>Entry Time &amp; Date</th>
+              <th>Entry Price</th>
+              <th>Exit Time &amp; Date</th>
+              <th>Exit Price</th>
+              <th>ROI%</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody id="paper-trades-body"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <script type="application/json" id="paper-summary-seed">{{ summary|tojson|safe }}</script>
+{% endblock %}
+{% block extra_body %}
+  <script src="{{ url_for('static', path='js/paper.js') }}" defer></script>
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -91,6 +91,43 @@
     border: 1px solid rgba(255, 255, 255, 0.2);
     color: inherit;
   }
+  .paper-settings-card {
+    margin-top: 1.5rem;
+    padding: 1.25rem;
+    border-radius: 10px;
+    border: 1px solid rgba(94, 160, 255, 0.2);
+    background: rgba(11, 16, 24, 0.75);
+  }
+  .paper-settings-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.35rem;
+  }
+  .paper-status-pill {
+    border-radius: 999px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.85rem;
+    background: rgba(255, 77, 77, 0.18);
+    color: var(--neg);
+  }
+  .paper-status-pill.active {
+    background: rgba(61, 220, 132, 0.18);
+    color: var(--pos);
+  }
+  .paper-settings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+  .paper-settings-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 1rem;
+  }
 </style>
 {% endblock %}
 {% block content %}
@@ -161,6 +198,38 @@
       {% if smtp_warning %}
       <p class="note status-error" style="margin-top:.5rem;">SMTP configuration incomplete: {{ smtp_missing_label }}</p>
       {% endif %}
+
+      <div class="paper-settings-card" id="paper-settings-card" data-status="{{ paper_summary.status }}" data-started="{{ paper_summary.started_at or '' }}">
+        <div class="paper-settings-header">
+          <h2 style="margin:0;">Paper Trading</h2>
+          <span id="paper-status-pill" class="paper-status-pill {% if paper_summary.status == 'active' %}active{% endif %}">
+            {% if paper_summary.status == 'active' %}Active{% else %}Inactive{% endif %}
+          </span>
+        </div>
+        <p class="note" style="margin:0;">Configure the simulated account balance and per-trade sizing limit.</p>
+        <div class="paper-settings-grid">
+          <label>Starting balance
+            <input name="paper_starting_balance" type="number" step="0.01" min="0" value="{{ '%.2f'|format(paper_settings.starting_balance) }}" />
+          </label>
+          <label>Max % of account per trade
+            <input name="paper_max_pct" type="number" step="0.1" min="0.1" value="{{ '%.2f'|format(paper_settings.max_pct) }}" />
+          </label>
+        </div>
+        <div class="paper-settings-actions">
+          <button type="button" class="btn btn-secondary" data-paper-action="start">Start</button>
+          <button type="button" class="btn btn-secondary" data-paper-action="stop">Stop</button>
+          <button type="button" class="btn btn-secondary" data-paper-action="restart">Restart</button>
+        </div>
+        <p id="paper-settings-status" class="note" style="margin-top:0.5rem;">
+          {% if paper_summary.status == 'active' and paper_summary.started_at %}
+            Active and running since {{ paper_summary.started_at }}
+          {% elif paper_summary.status == 'active' %}
+            Active and running.
+          {% else %}
+            Paper trading is currently inactive.
+          {% endif %}
+        </p>
+      </div>
 
   <div class="actions">
     <button type="submit">Save</button>
@@ -287,6 +356,77 @@
       toast.hidden = false;
       setTimeout(() => { toast.hidden = true; }, 2000);
     }
+
+    const paperStatusEl = document.getElementById('paper-settings-status');
+    const paperPill = document.getElementById('paper-status-pill');
+    const paperButtons = Array.from(document.querySelectorAll('[data-paper-action]'));
+    const paperDateFmt = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+
+    function renderPaperSummary(data) {
+      if (!data) return;
+      const status = (data.status || '').toLowerCase();
+      const startedRaw = data.started_at || '';
+      let startedLabel = startedRaw;
+      if (startedRaw) {
+        const parsed = new Date(startedRaw);
+        if (!Number.isNaN(parsed.valueOf())) {
+          startedLabel = paperDateFmt.format(parsed);
+        }
+      }
+      if (paperStatusEl) {
+        if (status === 'active' && startedLabel) {
+          paperStatusEl.textContent = `Active and running since ${startedLabel}`;
+        } else if (status === 'active') {
+          paperStatusEl.textContent = 'Active and running.';
+        } else {
+          paperStatusEl.textContent = 'Paper trading is currently inactive.';
+        }
+      }
+      if (paperPill) {
+        if (status === 'active') {
+          paperPill.classList.add('active');
+          paperPill.textContent = 'Active';
+        } else {
+          paperPill.classList.remove('active');
+          paperPill.textContent = 'Inactive';
+        }
+      }
+    }
+
+    function setPaperButtonsDisabled(disabled) {
+      paperButtons.forEach((btn) => {
+        btn.disabled = disabled;
+      });
+    }
+
+    function requestPaperAction(action) {
+      if (!action) return;
+      setPaperButtonsDisabled(true);
+      fetch(`/paper/${action}`, {
+        method: 'POST',
+        credentials: 'same-origin',
+      })
+        .then((resp) => {
+          if (!resp.ok) throw new Error('request_failed');
+          return resp.json();
+        })
+        .then((payload) => {
+          renderPaperSummary(payload);
+          const msg = action === 'start' ? 'Paper trading started.' : action === 'stop' ? 'Paper trading stopped.' : 'Paper trading restarted.';
+          showToast(msg, true);
+        })
+        .catch(() => {
+          showToast('Unable to update paper trading.', false);
+        })
+        .finally(() => setPaperButtonsDisabled(false));
+    }
+
+    paperButtons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const action = btn.dataset.paperAction;
+        requestPaperAction(action);
+      });
+    });
 
     const sendBtn = document.getElementById('send_test_alert');
     const testForm = document.getElementById('test-alert-form');

--- a/tests/test_migration_0009.py
+++ b/tests/test_migration_0009.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import sqlite3
+
+from alembic import command
+from alembic.config import Config
+
+import db
+
+
+def _alembic_config(db_path: Path) -> Config:
+    cfg = Config(str(Path(__file__).resolve().parents[1] / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def test_migration_0009_creates_and_drops_tables(tmp_path):
+    db_path = tmp_path / "paper_mig.db"
+    db.DB_PATH = str(db_path)
+    cfg = _alembic_config(db_path)
+
+    command.upgrade(cfg, "0008")
+    command.upgrade(cfg, "0009")
+
+    conn = sqlite3.connect(db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='paper_trades'")
+    assert cur.fetchone() is not None
+    cur.execute("PRAGMA table_info(paper_trades)")
+    cols = {row[1] for row in cur.fetchall()}
+    assert {"executed_at", "interval", "ticker"}.issubset(cols)
+    cur.execute("PRAGMA index_list('paper_trades')")
+    indexes = {row[1] for row in cur.fetchall()}
+    assert "ix_paper_trades_ticker" in indexes
+    assert "ix_paper_trades_executed_at" in indexes
+
+    command.downgrade(cfg, "0008")
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='paper_trades'")
+    assert cur.fetchone() is None
+    conn.close()

--- a/tests/test_paper_trading.py
+++ b/tests/test_paper_trading.py
@@ -1,0 +1,287 @@
+import csv
+import logging
+from datetime import datetime, timezone
+from typing import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import db
+import routes
+from db import get_db
+from services import paper_trading
+
+
+@pytest.fixture
+def db_cursor(tmp_path) -> Iterator:
+    db.DB_PATH = str(tmp_path / "paper.db")
+    db.init_db()
+    gen = get_db()
+    cursor = next(gen)
+    try:
+        yield cursor
+    finally:
+        try:
+            cursor.connection.close()
+        except Exception:
+            pass
+        try:
+            gen.close()
+        except Exception:
+            pass
+
+
+def _restart_active(cursor, *, when: datetime | None = None) -> None:
+    paper_trading.restart_engine(cursor, now=when)
+    paper_trading.start_engine(cursor, now=when)
+
+
+def test_calculate_max_contracts_respects_cap():
+    qty, cap = paper_trading.calculate_max_contracts(10000, 25, 2.5)
+    assert qty == 10
+    assert cap == pytest.approx(2500)
+
+
+def test_calculate_max_contracts_handles_rounding():
+    qty, cap = paper_trading.calculate_max_contracts(15000, 12.5, 1.3333)
+    assert qty * 1.3333 * 100 <= cap + 1e-6
+    assert qty == 14  # floor(1875/133.33) while staying under cap
+
+
+def test_calculate_roi_basic():
+    assert paper_trading.calculate_roi(2.5, 3.0) == pytest.approx(20.0)
+
+
+def test_resolve_fill_price_fallbacks():
+    mid, src = paper_trading.resolve_fill_price(None, 3.5, None, None)
+    assert mid == pytest.approx(3.5)
+    assert src == "recent_mid"
+    synth, src2 = paper_trading.resolve_fill_price(None, None, 2.0, 0.5)
+    assert synth == pytest.approx(1.0)
+    assert src2 == "synthetic_delta"
+
+
+def test_open_position_dedupe(db_cursor):
+    _restart_active(db_cursor, when=datetime(2024, 5, 1, tzinfo=timezone.utc))
+    first = paper_trading.open_position(
+        db_cursor,
+        ticker="AAPL",
+        call_put="CALL",
+        strike=180,
+        expiry="2024-09-20",
+        interval="15m",
+        mid_price=2.5,
+        recent_mid=None,
+        underlying_move=None,
+        delta=0.4,
+        source_alert_id="alert-1",
+    )
+    assert first is not None
+    duplicate_alert = paper_trading.open_position(
+        db_cursor,
+        ticker="AAPL",
+        call_put="CALL",
+        strike=180,
+        expiry="2024-09-20",
+        interval="15m",
+        mid_price=2.5,
+        recent_mid=None,
+        underlying_move=None,
+        delta=0.4,
+        source_alert_id="alert-1",
+    )
+    assert duplicate_alert is None
+    duplicate_open = paper_trading.open_position(
+        db_cursor,
+        ticker="AAPL",
+        call_put="CALL",
+        strike=180,
+        expiry="2024-09-20",
+        interval="15m",
+        mid_price=2.5,
+        recent_mid=None,
+        underlying_move=None,
+        delta=0.4,
+        source_alert_id="alert-2",
+    )
+    assert duplicate_open is None
+    count = db_cursor.execute("SELECT COUNT(1) FROM paper_trades").fetchone()[0]
+    assert count == 1
+
+
+def test_open_position_skips_when_no_price(db_cursor, caplog):
+    caplog.set_level(logging.INFO, logger="services.paper_trading")
+    _restart_active(db_cursor)
+    result = paper_trading.open_position(
+        db_cursor,
+        ticker="MSFT",
+        call_put="CALL",
+        strike=300,
+        expiry="2024-11-15",
+        interval="5m",
+        mid_price=None,
+        recent_mid=None,
+        underlying_move=None,
+        delta=None,
+    )
+    assert result is None
+    assert any(
+        getattr(record, "reason", "") == "no_price"
+        for record in caplog.records
+        if record.name == "services.paper_trading"
+    )
+
+
+def test_restart_engine_idempotency(db_cursor):
+    paper_trading.update_settings(db_cursor, starting_balance=7500, max_pct=15)
+    first = paper_trading.restart_engine(db_cursor, now=datetime(2024, 6, 1, tzinfo=timezone.utc))
+    assert first.status == "active"
+    paper_trading.restart_engine(db_cursor, now=datetime(2024, 6, 2, tzinfo=timezone.utc))
+    equity_points = db_cursor.execute("SELECT COUNT(1) FROM paper_equity").fetchone()[0]
+    trades = db_cursor.execute("SELECT COUNT(1) FROM paper_trades").fetchone()[0]
+    assert equity_points == 1
+    assert trades == 0
+
+
+def test_export_trades_csv_schema(db_cursor):
+    _restart_active(db_cursor)
+    trade_id = paper_trading.open_position(
+        db_cursor,
+        ticker="TSLA",
+        call_put="PUT",
+        strike=150,
+        expiry="2024-09-20",
+        interval="30m",
+        mid_price=1.5,
+        recent_mid=None,
+        underlying_move=None,
+        delta=0.45,
+        source_alert_id="test-tsla",
+    )
+    assert trade_id is not None
+    paper_trading.close_position(
+        db_cursor,
+        trade_id,
+        exit_price=1.8,
+        reason="target",
+    )
+    csv_text, filename = paper_trading.export_trades_csv(db_cursor, None)
+    assert filename == "paper_trades.csv"
+    rows = list(csv.reader(csv_text.strip().splitlines()))
+    assert rows[0] == [
+        "Ticker",
+        "Call/Put",
+        "Strike–Expiry",
+        "Quantity",
+        "Entry Time & Date",
+        "Entry Price",
+        "Exit Time & Date",
+        "Exit Price",
+        "ROI%",
+        "Status",
+    ]
+    assert rows[1][0] == "TSLA"
+    assert rows[1][-1] == "closed"
+
+
+def test_paper_trade_lifecycle(db_cursor, caplog):
+    caplog.set_level(logging.INFO, logger="services.paper_trading")
+    paper_trading.update_settings(db_cursor, starting_balance=5000, max_pct=20)
+    paper_trading.restart_engine(db_cursor, now=datetime(2024, 5, 1, tzinfo=timezone.utc))
+    trade_id = paper_trading.open_position(
+        db_cursor,
+        ticker="TSLA",
+        call_put="PUT",
+        strike=150,
+        expiry="2024-09-20",
+        interval="30m",
+        mid_price=None,
+        recent_mid=1.2,
+        underlying_move=None,
+        delta=0.5,
+        source_alert_id="tsla-hit",
+    )
+    assert trade_id is not None
+    summary_after_entry = paper_trading.get_summary(db_cursor)
+    assert summary_after_entry["balance"] < summary_after_entry["starting_balance"]
+    trade = paper_trading.close_position(
+        db_cursor,
+        trade_id,
+        exit_price=1.8,
+        reason="target",
+    )
+    assert trade is not None
+    assert trade.interval == "30m"
+    assert trade.executed_at
+    summary_after_exit = paper_trading.get_summary(db_cursor)
+    assert summary_after_exit["balance"] > summary_after_entry["balance"]
+    points = paper_trading.get_equity_points(db_cursor, "1d")
+    assert len(points) >= 2
+    trades = paper_trading.list_trades(db_cursor, "all")
+    assert trades and trades[0]["status"] == "closed"
+    assert any(record.message == "paper_trade_opened" for record in caplog.records)
+    assert any(record.message == "paper_trade_closed" for record in caplog.records)
+
+
+def test_paper_page_roi_chip_class(tmp_path):
+    db.DB_PATH = str(tmp_path / "paper_ui.db")
+    db.init_db()
+    gen = get_db()
+    cursor = next(gen)
+    try:
+        paper_trading.restart_engine(cursor)
+        trade_id = paper_trading.open_position(
+            cursor,
+            ticker="NFLX",
+            call_put="CALL",
+            strike=400,
+            expiry="2024-12-20",
+            interval="1h",
+            mid_price=2.0,
+            recent_mid=None,
+            underlying_move=None,
+            delta=0.5,
+            source_alert_id="nflx-hit",
+        )
+        assert trade_id is not None
+        paper_trading.close_position(
+            cursor,
+            trade_id,
+            exit_price=1.0,
+            reason="stop",
+        )
+    finally:
+        try:
+            cursor.connection.close()
+        except Exception:
+            pass
+        try:
+            gen.close()
+        except Exception:
+            pass
+
+    app = FastAPI()
+    app.include_router(routes.router)
+    client = TestClient(app)
+    res = client.get("/paper")
+    assert res.status_code == 200
+    assert "paper-roi-chip chip-neg" in res.text
+
+
+def test_trades_api_rejects_invalid_status(db_cursor):
+    app = FastAPI()
+    app.include_router(routes.router)
+    client = TestClient(app)
+    response = client.get("/paper/trades?status=bogus")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid status filter"
+
+
+def test_equity_api_requires_valid_range(db_cursor):
+    app = FastAPI()
+    app.include_router(routes.router)
+    client = TestClient(app)
+    response = client.get("/paper/equity?range=10y")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid range"


### PR DESCRIPTION
## Summary
- make the paper trading migration idempotent, add interval/executed-at fields, and create indexes/unique guard for ticker and source IDs
- enforce strict sizing caps, alert dedupe, interval tracking, and CSV formatting in the paper trading service while tightening API validation/rate limiting
- polish the paper trading UI and settings to format ROI/status locally and cover the behavior with migration and ROI/API tests

## Testing
- pytest -q *(completes with 80 tests passing but requires interrupt because of background thread warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d777c1d5748329b0058ee19cb478b5