### PR TITLE
Add high-frequency paper scalper engine and metrics endpoint

### DIFF
--- a/services/scalper/__init__.py
+++ b/services/scalper/__init__.py
@@ -1,0 +1,5 @@
+"""Scalper engines for paper trading."""
+
+from . import hf_engine, lf_engine, shared
+
+__all__ = ["lf_engine", "hf_engine", "shared"]

--- a/services/scalper/lf_engine.py
+++ b/services/scalper/lf_engine.py
@@ -1,0 +1,889 @@
+"""Low-frequency paper scalper engine.
+
+The implementation is intentionally self-contained and focuses on deterministic
+behaviour so it can be exercised in unit tests without external market data.
+"""
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from utils import TZ, now_et
+
+from .shared import (
+    FeeModel,
+    apply_slippage,
+    calculate_position_size as _shared_position_size,
+    compute_trade_metrics,
+    summarize_backtest,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TICKERS = "SPY,QQQ,TSLA,NVDA"
+
+
+@dataclass(slots=True)
+class LFSettings:
+    starting_balance: float
+    pct_per_trade: float
+    daily_trade_cap: int
+    tickers: str
+    profit_target_pct: float
+    max_adverse_pct: float
+    time_cap_minutes: int
+    session_start: str
+    session_end: str
+    allow_premarket: bool
+    allow_postmarket: bool
+    per_contract_fee: float
+    per_order_fee: float
+    rsi_filter: bool
+
+
+@dataclass(slots=True)
+class LFStatus:
+    status: str
+    started_at: Optional[str]
+    account_equity: float
+    open_positions: int
+    realized_pl_day: float
+    unrealized_pl: float
+    win_rate_pct: float
+
+
+@dataclass(slots=True)
+class LFActivity:
+    id: int
+    trade_date: str
+    ticker: str
+    option_type: str
+    strike: float | None
+    expiry: str | None
+    qty: int
+    entry_time: str
+    entry_price: float
+    exit_time: str | None
+    exit_price: float | None
+    roi_pct: float | None
+    fees: float
+    status: str
+
+
+@dataclass(slots=True)
+class EquityPoint:
+    ts: str
+    balance: float
+
+
+def _ensure_schema(db) -> None:
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS scalper_lf_settings (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            starting_balance REAL NOT NULL,
+            pct_per_trade REAL NOT NULL,
+            daily_trade_cap INTEGER NOT NULL,
+            tickers TEXT NOT NULL,
+            profit_target_pct REAL NOT NULL,
+            max_adverse_pct REAL NOT NULL,
+            time_cap_minutes INTEGER NOT NULL,
+            session_start TEXT NOT NULL,
+            session_end TEXT NOT NULL,
+            allow_premarket INTEGER NOT NULL,
+            allow_postmarket INTEGER NOT NULL,
+            per_contract_fee REAL NOT NULL,
+            per_order_fee REAL NOT NULL,
+            rsi_filter INTEGER NOT NULL
+        )
+        """
+    )
+    db.execute(
+        """
+        INSERT OR IGNORE INTO scalper_lf_settings(
+            id, starting_balance, pct_per_trade, daily_trade_cap, tickers,
+            profit_target_pct, max_adverse_pct, time_cap_minutes,
+            session_start, session_end, allow_premarket, allow_postmarket,
+            per_contract_fee, per_order_fee, rsi_filter
+        ) VALUES(
+            1, 100000.0, 3.0, 20, ?,
+            6.0, -3.0, 15,
+            '09:30', '16:00', 0, 0,
+            0.65, 0.0, 0
+        )
+        """,
+        (_DEFAULT_TICKERS,),
+    )
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS scalper_lf_state (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            status TEXT NOT NULL,
+            started_at TEXT
+        )
+        """
+    )
+    db.execute(
+        """INSERT OR IGNORE INTO scalper_lf_state(id, status, started_at)
+               VALUES(1, 'inactive', NULL)"""
+    )
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS scalper_lf_equity (
+            ts TEXT PRIMARY KEY,
+            balance REAL NOT NULL
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS scalper_lf_activity (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            trade_date TEXT NOT NULL,
+            ticker TEXT NOT NULL,
+            option_type TEXT NOT NULL,
+            strike REAL,
+            expiry TEXT,
+            qty INTEGER NOT NULL,
+            entry_time TEXT NOT NULL,
+            entry_price REAL NOT NULL,
+            exit_time TEXT,
+            exit_price REAL,
+            roi_pct REAL,
+            fees REAL NOT NULL,
+            status TEXT NOT NULL,
+            dedupe_key TEXT NOT NULL,
+            reason TEXT,
+            realized_pl REAL,
+            net_pl REAL,
+            session_id TEXT
+        )
+        """
+    )
+    db.connection.commit()
+
+
+def load_settings(db) -> LFSettings:
+    _ensure_schema(db)
+    row = db.execute(
+        """
+        SELECT starting_balance, pct_per_trade, daily_trade_cap, tickers,
+               profit_target_pct, max_adverse_pct, time_cap_minutes,
+               session_start, session_end, allow_premarket, allow_postmarket,
+               per_contract_fee, per_order_fee, rsi_filter
+          FROM scalper_lf_settings WHERE id=1
+        """
+    ).fetchone()
+    assert row is not None
+    return LFSettings(
+        starting_balance=float(row["starting_balance"]),
+        pct_per_trade=float(row["pct_per_trade"]),
+        daily_trade_cap=int(row["daily_trade_cap"]),
+        tickers=str(row["tickers"] or _DEFAULT_TICKERS),
+        profit_target_pct=float(row["profit_target_pct"]),
+        max_adverse_pct=float(row["max_adverse_pct"]),
+        time_cap_minutes=int(row["time_cap_minutes"]),
+        session_start=str(row["session_start"]),
+        session_end=str(row["session_end"]),
+        allow_premarket=bool(row["allow_premarket"]),
+        allow_postmarket=bool(row["allow_postmarket"]),
+        per_contract_fee=float(row["per_contract_fee"]),
+        per_order_fee=float(row["per_order_fee"]),
+        rsi_filter=bool(row["rsi_filter"]),
+    )
+
+
+def update_settings(
+    db,
+    *,
+    starting_balance: float,
+    pct_per_trade: float,
+    daily_trade_cap: int,
+    tickers: Sequence[str] | str,
+    profit_target_pct: float,
+    max_adverse_pct: float,
+    time_cap_minutes: int,
+    session_start: str,
+    session_end: str,
+    allow_premarket: bool,
+    allow_postmarket: bool,
+    per_contract_fee: float,
+    per_order_fee: float,
+    rsi_filter: bool,
+) -> LFSettings:
+    _ensure_schema(db)
+    pct_value = max(0.5, min(float(pct_per_trade), 10.0))
+    balance_value = max(0.0, float(starting_balance))
+    cap_value = max(0, int(daily_trade_cap))
+    tickers_value = ",".join(tickers) if isinstance(tickers, Sequence) and not isinstance(tickers, str) else str(tickers)
+    tickers_value = ",".join(filter(None, [t.strip().upper() for t in tickers_value.split(",")])) or _DEFAULT_TICKERS
+    target_pct = float(profit_target_pct)
+    stop_pct = float(max_adverse_pct)
+    time_cap = max(1, int(time_cap_minutes))
+    per_contract = max(0.0, float(per_contract_fee))
+    per_order = max(0.0, float(per_order_fee))
+    db.execute(
+        """
+        UPDATE scalper_lf_settings
+           SET starting_balance=?, pct_per_trade=?, daily_trade_cap=?, tickers=?,
+               profit_target_pct=?, max_adverse_pct=?, time_cap_minutes=?,
+               session_start=?, session_end=?, allow_premarket=?, allow_postmarket=?,
+               per_contract_fee=?, per_order_fee=?, rsi_filter=?
+         WHERE id=1
+        """,
+        (
+            balance_value,
+            pct_value,
+            cap_value,
+            tickers_value,
+            target_pct,
+            stop_pct,
+            time_cap,
+            session_start,
+            session_end,
+            1 if allow_premarket else 0,
+            1 if allow_postmarket else 0,
+            per_contract,
+            per_order,
+            1 if rsi_filter else 0,
+        ),
+    )
+    db.connection.commit()
+    return load_settings(db)
+
+
+def _now_utc(now: datetime | None = None) -> datetime:
+    if now is None:
+        now = datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    return now.astimezone(timezone.utc)
+
+
+def _ensure_equity_seed(db, settings: LFSettings, *, now: datetime | None = None) -> None:
+    row = db.execute("SELECT COUNT(1) FROM scalper_lf_equity").fetchone()
+    count = int(row[0]) if row else 0
+    if count:
+        return
+    current = _now_utc(now).isoformat()
+    db.execute(
+        "INSERT OR REPLACE INTO scalper_lf_equity(ts, balance) VALUES(?, ?)",
+        (current, float(settings.starting_balance)),
+    )
+    db.connection.commit()
+
+
+def start_engine(db, *, now: datetime | None = None) -> LFStatus:
+    _ensure_schema(db)
+    settings = load_settings(db)
+    started = _now_utc(now).isoformat()
+    db.execute(
+        "UPDATE scalper_lf_state SET status='active', started_at=? WHERE id=1",
+        (started,),
+    )
+    db.connection.commit()
+    _ensure_equity_seed(db, settings, now=now)
+    return get_status(db)
+
+
+def stop_engine(db, *, now: datetime | None = None) -> LFStatus:
+    _ensure_schema(db)
+    db.execute("UPDATE scalper_lf_state SET status='inactive' WHERE id=1")
+    db.connection.commit()
+    return get_status(db)
+
+
+def restart_engine(db, *, now: datetime | None = None) -> LFStatus:
+    _ensure_schema(db)
+    settings = load_settings(db)
+    started = _now_utc(now).isoformat()
+    db.execute(
+        "UPDATE scalper_lf_state SET status='active', started_at=? WHERE id=1",
+        (started,),
+    )
+    db.connection.commit()
+    _ensure_equity_seed(db, settings, now=now)
+    return get_status(db)
+
+
+def get_status(db) -> LFStatus:
+    _ensure_schema(db)
+    state = db.execute(
+        "SELECT status, started_at FROM scalper_lf_state WHERE id=1"
+    ).fetchone()
+    status = str(state["status"]) if state else "inactive"
+    started_at = state["started_at"] if state else None
+    equity = _latest_equity(db)
+    open_positions = _count_open_positions(db)
+    realized_today = _realized_today(db)
+    unrealized = _unrealized_pl(db)
+    win_rate = _win_rate(db)
+    return LFStatus(
+        status=status,
+        started_at=started_at,
+        account_equity=equity,
+        open_positions=open_positions,
+        realized_pl_day=realized_today,
+        unrealized_pl=unrealized,
+        win_rate_pct=win_rate,
+    )
+
+
+def status_payload(db) -> Dict[str, Any]:
+    st = get_status(db)
+    settings = load_settings(db)
+    return {
+        "status": st.status,
+        "started_at": st.started_at,
+        "account_equity": st.account_equity,
+        "open_positions": st.open_positions,
+        "realized_pl_day": st.realized_pl_day,
+        "unrealized_pl": st.unrealized_pl,
+        "win_rate_pct": st.win_rate_pct,
+        "settings": {
+            "starting_balance": settings.starting_balance,
+            "pct_per_trade": settings.pct_per_trade,
+            "daily_trade_cap": settings.daily_trade_cap,
+            "tickers": settings.tickers,
+            "profit_target_pct": settings.profit_target_pct,
+            "max_adverse_pct": settings.max_adverse_pct,
+            "time_cap_minutes": settings.time_cap_minutes,
+            "session_start": settings.session_start,
+            "session_end": settings.session_end,
+            "allow_premarket": settings.allow_premarket,
+            "allow_postmarket": settings.allow_postmarket,
+            "per_contract_fee": settings.per_contract_fee,
+            "per_order_fee": settings.per_order_fee,
+            "rsi_filter": settings.rsi_filter,
+        },
+    }
+
+
+
+
+def metrics_snapshot(db) -> Dict[str, float]:
+    _ensure_schema(db)
+    settings = load_settings(db)
+    rows = db.execute(
+        """
+        SELECT entry_time, exit_time, roi_pct, realized_pl, net_pl
+          FROM scalper_lf_activity
+         WHERE status='closed'
+         ORDER BY exit_time ASC
+        """
+    ).fetchall()
+    return dict(compute_trade_metrics(rows, starting_balance=settings.starting_balance))
+
+
+def _latest_equity(db) -> float:
+    row = db.execute(
+        "SELECT balance FROM scalper_lf_equity ORDER BY ts DESC LIMIT 1"
+    ).fetchone()
+    if row:
+        return float(row["balance"])
+    settings = load_settings(db)
+    return float(settings.starting_balance)
+
+
+def _count_open_positions(db) -> int:
+    row = db.execute(
+        "SELECT COUNT(1) FROM scalper_lf_activity WHERE status='open'"
+    ).fetchone()
+    return int(row[0]) if row else 0
+
+
+def _realized_today(db) -> float:
+    today = now_et().date()
+    start = datetime.combine(today, datetime.min.time(), tzinfo=TZ).astimezone(timezone.utc)
+    end = start + timedelta(days=1)
+    row = db.execute(
+        """
+        SELECT COALESCE(SUM(net_pl), 0) FROM scalper_lf_activity
+         WHERE exit_time IS NOT NULL AND status='closed'
+           AND exit_time >= ? AND exit_time < ?
+        """,
+        (start.isoformat(), end.isoformat()),
+    ).fetchone()
+    return float(row[0]) if row else 0.0
+
+
+def _unrealized_pl(db) -> float:
+    row = db.execute(
+        """
+        SELECT COALESCE(SUM((COALESCE(mark_price, entry_price) - entry_price) * qty * 100), 0)
+          FROM scalper_lf_activity
+         WHERE status='open'
+        """
+    ).fetchone()
+    return float(row[0]) if row else 0.0
+
+
+def _win_rate(db, lookback: int = 20) -> float:
+    rows = db.execute(
+        """
+        SELECT net_pl FROM scalper_lf_activity
+         WHERE status='closed'
+         ORDER BY exit_time DESC
+         LIMIT ?
+        """,
+        (lookback,),
+    ).fetchall()
+    if not rows:
+        return 0.0
+    wins = sum(1 for row in rows if float(row["net_pl"] or 0.0) > 0.0)
+    return round(wins / len(rows) * 100.0, 2)
+
+
+def calculate_position_size(balance: float, pct_per_trade: float, mid_price: float) -> int:
+    return _shared_position_size(balance, pct_per_trade, mid_price)
+
+
+def _apply_tick(mid_price: float, *, is_buy: bool, ticks: int = 1) -> float:
+    side = "buy" if is_buy else "sell"
+    return apply_slippage(mid_price, side=side, ticks=ticks)
+
+
+def _order_fees(qty: int, *, per_contract: float, per_order: float) -> float:
+    model = FeeModel(per_contract=float(per_contract), per_order=float(per_order))
+    return model.order_fees(qty)
+
+
+def open_trade(
+    db,
+    *,
+    ticker: str,
+    option_type: str,
+    strike: float | None,
+    expiry: str | None,
+    mid_price: float,
+    entry_time: datetime | None = None,
+    settings: LFSettings | None = None,
+) -> Optional[int]:
+    _ensure_schema(db)
+    settings = settings or load_settings(db)
+    state = get_status(db)
+    if state.status != "active":
+        logger.info("lf_trade_skipped status=%s", state.status)
+        return None
+
+    entry_dt = _now_utc(entry_time)
+    dedupe_key = _dedupe_key(ticker, option_type, strike, expiry)
+    existing = db.execute(
+        "SELECT id FROM scalper_lf_activity WHERE status='open' AND dedupe_key=?",
+        (dedupe_key,),
+    ).fetchone()
+    if existing:
+        logger.info("lf_trade_dedupe ticker=%s option=%s", ticker, option_type)
+        return None
+
+    if _daily_trade_count(db, entry_dt.date()) >= settings.daily_trade_cap:
+        logger.info("lf_trade_cap_reached date=%s cap=%s", entry_dt.date(), settings.daily_trade_cap)
+        return None
+
+    equity = _latest_equity(db)
+    qty = calculate_position_size(equity, settings.pct_per_trade, mid_price)
+    if qty <= 0:
+        logger.info("lf_trade_qty_zero ticker=%s", ticker)
+        return None
+
+    entry_price = _apply_tick(mid_price, is_buy=True)
+    fees = _order_fees(qty, per_contract=settings.per_contract_fee, per_order=settings.per_order_fee)
+    trade_date = entry_dt.date().isoformat()
+    db.execute(
+        """
+        INSERT INTO scalper_lf_activity(
+            trade_date, ticker, option_type, strike, expiry, qty,
+            entry_time, entry_price, fees, status, dedupe_key
+        ) VALUES(?,?,?,?,?,?,?,?,?,?,?)
+        """,
+        (
+            trade_date,
+            ticker.upper(),
+            option_type.upper(),
+            strike,
+            expiry,
+            qty,
+            entry_dt.isoformat(),
+            entry_price,
+            fees,
+            "open",
+            dedupe_key,
+        ),
+    )
+    db.connection.commit()
+    row = db.execute("SELECT last_insert_rowid() AS id").fetchone()
+    return int(row["id"]) if row else None
+
+
+def _daily_trade_count(db, session_date: date) -> int:
+    start = datetime.combine(session_date, datetime.min.time(), tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    row = db.execute(
+        """
+        SELECT COUNT(1) FROM scalper_lf_activity
+         WHERE entry_time >= ? AND entry_time < ?
+        """,
+        (start.isoformat(), end.isoformat()),
+    ).fetchone()
+    return int(row[0]) if row else 0
+
+
+def _dedupe_key(ticker: str, option_type: str, strike: float | None, expiry: str | None) -> str:
+    parts = [ticker.upper(), option_type.upper()]
+    if strike is not None:
+        parts.append(f"{float(strike):.2f}")
+    if expiry:
+        parts.append(str(expiry))
+    return "|".join(parts)
+
+
+def close_trade(
+    db,
+    trade_id: int,
+    *,
+    mid_price: float,
+    exit_time: datetime | None = None,
+    reason: str = "exit",
+    settings: LFSettings | None = None,
+) -> Optional[LFActivity]:
+    _ensure_schema(db)
+    settings = settings or load_settings(db)
+    row = db.execute(
+        "SELECT id, qty, entry_price, fees FROM scalper_lf_activity WHERE id=? AND status='open'",
+        (trade_id,),
+    ).fetchone()
+    if not row:
+        return None
+    exit_dt = _now_utc(exit_time)
+    qty = int(row["qty"])
+    entry_price = float(row["entry_price"])
+    entry_fees = float(row["fees"])
+    exit_price = _apply_tick(mid_price, is_buy=False)
+    exit_fees = _order_fees(qty, per_contract=settings.per_contract_fee, per_order=settings.per_order_fee)
+    gross = (exit_price - entry_price) * qty * 100.0
+    total_fees = entry_fees + exit_fees
+    net = gross - total_fees
+    roi = 0.0 if entry_price <= 0 else round((exit_price - entry_price) / entry_price * 100.0, 2)
+
+    db.execute(
+        """
+        UPDATE scalper_lf_activity
+           SET exit_time=?, exit_price=?, roi_pct=?, fees=?, status='closed',
+               reason=?, realized_pl=?, net_pl=?
+         WHERE id=?
+        """,
+        (
+            exit_dt.isoformat(),
+            exit_price,
+            roi,
+            total_fees,
+            reason,
+            gross,
+            net,
+            trade_id,
+        ),
+    )
+    new_equity = _latest_equity(db) + net
+    db.execute(
+        "INSERT INTO scalper_lf_equity(ts, balance) VALUES(?, ?)",
+        (exit_dt.isoformat(), new_equity),
+    )
+    db.connection.commit()
+    updated = db.execute(
+        """
+        SELECT id, trade_date, ticker, option_type, strike, expiry, qty,
+               entry_time, entry_price, exit_time, exit_price, roi_pct,
+               fees, status
+          FROM scalper_lf_activity WHERE id=?
+        """,
+        (trade_id,),
+    ).fetchone()
+    if not updated:
+        return None
+    return LFActivity(
+        id=int(updated["id"]),
+        trade_date=str(updated["trade_date"]),
+        ticker=str(updated["ticker"]),
+        option_type=str(updated["option_type"]),
+        strike=updated["strike"],
+        expiry=updated["expiry"],
+        qty=int(updated["qty"]),
+        entry_time=str(updated["entry_time"]),
+        entry_price=float(updated["entry_price"]),
+        exit_time=updated["exit_time"],
+        exit_price=updated["exit_price"],
+        roi_pct=updated["roi_pct"],
+        fees=float(updated["fees"]),
+        status=str(updated["status"]),
+    )
+
+
+def list_activity(db, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+    _ensure_schema(db)
+    query = (
+        "SELECT trade_date, ticker, option_type, strike, expiry, qty, entry_time,"
+        " entry_price, exit_time, exit_price, roi_pct, fees, status FROM"
+        " scalper_lf_activity ORDER BY entry_time DESC"
+    )
+    if limit:
+        query += f" LIMIT {int(limit)}"
+    rows = db.execute(query).fetchall()
+    results: List[Dict[str, Any]] = []
+    for row in rows:
+        results.append(
+            {
+                "date": row["trade_date"],
+                "ticker": row["ticker"],
+                "call_put": row["option_type"],
+                "strike": row["strike"],
+                "expiry": row["expiry"],
+                "qty": row["qty"],
+                "entry_time": row["entry_time"],
+                "entry_price": row["entry_price"],
+                "exit_time": row["exit_time"],
+                "exit_price": row["exit_price"],
+                "roi_pct": row["roi_pct"],
+                "fees": row["fees"],
+                "status": row["status"],
+            }
+        )
+    return results
+
+
+def export_activity_csv(db) -> Tuple[str, str]:
+    rows = list_activity(db)
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(
+        [
+            "Date",
+            "Ticker",
+            "Call/Put",
+            "Strike-Expiry",
+            "Qty",
+            "Entry Time",
+            "Entry Price",
+            "Exit Time",
+            "Exit Price",
+            "ROI%",
+            "Fees",
+        ]
+    )
+    for row in rows:
+        strike = row["strike"]
+        if strike is None:
+            strike_label = "—"
+        else:
+            strike_label = f"${float(strike):.2f}".rstrip("0").rstrip(".")
+        expiry = row["expiry"] or "—"
+        combo = f"{strike_label}-{expiry}"
+        roi = row["roi_pct"]
+        roi_label = "" if roi is None else f"{float(roi):.2f}"
+        writer.writerow(
+            [
+                row["date"],
+                row["ticker"],
+                row["call_put"],
+                combo,
+                row["qty"],
+                row["entry_time"],
+                row["entry_price"],
+                row["exit_time"],
+                row["exit_price"],
+                roi_label,
+                f"{float(row['fees']):.2f}",
+            ]
+        )
+    return output.getvalue(), "scalper_lf_activity.csv"
+
+
+def get_equity_points(db, range_key: str) -> List[EquityPoint]:
+    _ensure_schema(db)
+    now = _now_utc()
+    if range_key == "1d":
+        start = now - timedelta(days=1)
+    elif range_key == "1w":
+        start = now - timedelta(weeks=1)
+    elif range_key == "1m":
+        start = now - timedelta(days=30)
+    elif range_key == "1y":
+        start = now - timedelta(days=365)
+    else:
+        raise ValueError("invalid range")
+    rows = db.execute(
+        """
+        SELECT ts, balance FROM scalper_lf_equity
+         WHERE ts >= ?
+         ORDER BY ts ASC
+        """,
+        (start.isoformat(),),
+    ).fetchall()
+    return [EquityPoint(ts=row["ts"], balance=float(row["balance"])) for row in rows]
+
+
+async def _fetch_schwab_quote(symbol: str) -> Dict[str, Any]:  # pragma: no cover - network
+    from services import schwab_client
+
+    return await schwab_client.get_quote(symbol)
+
+
+async def _fetch_yfinance_quote(symbol: str) -> Dict[str, Any]:  # pragma: no cover - network
+    from services import data_provider
+
+    return await data_provider._fetch_yfinance_quote(symbol)
+
+
+async def fetch_quote(symbol: str) -> Dict[str, Any]:
+    try:
+        quote = await _fetch_schwab_quote(symbol)
+    except Exception:
+        quote = {}
+    if quote:
+        return quote
+    return await _fetch_yfinance_quote(symbol)
+
+
+def fetch_quote_sync(symbol: str) -> Dict[str, Any]:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop and loop.is_running():
+        return asyncio.run_coroutine_threadsafe(fetch_quote(symbol), loop).result()
+    return asyncio.run(fetch_quote(symbol))
+
+
+def _rsi(values: Sequence[float], period: int = 14) -> List[float]:
+    result: List[float] = []
+    gains: List[float] = []
+    losses: List[float] = []
+    for i, value in enumerate(values):
+        if i == 0:
+            gains.append(0.0)
+            losses.append(0.0)
+            result.append(50.0)
+            continue
+        delta = value - values[i - 1]
+        gains.append(max(delta, 0.0))
+        losses.append(max(-delta, 0.0))
+        if i < period:
+            result.append(50.0)
+            continue
+        avg_gain = sum(gains[i - period + 1 : i + 1]) / period
+        avg_loss = sum(losses[i - period + 1 : i + 1]) / period
+        if avg_loss == 0:
+            result.append(100.0)
+        else:
+            rs = avg_gain / avg_loss
+            result.append(100 - 100 / (1 + rs))
+    return result
+
+
+def evaluate_exit(
+    *,
+    entry_price: float,
+    bars: Sequence[Mapping[str, Any]],
+    target_pct: float,
+    stop_pct: float,
+    time_cap_minutes: int,
+) -> Tuple[float, str, Optional[str]]:
+    if not bars:
+        return entry_price, "timeout", None
+    start_time: Optional[datetime] = None
+    for bar in bars:
+        ts_raw = bar.get("ts")
+        price = float(bar.get("close", entry_price))
+        if isinstance(ts_raw, str):
+            try:
+                ts_val = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+            except ValueError:
+                ts_val = None
+        else:
+            ts_val = None
+        if start_time is None and ts_val is not None:
+            start_time = ts_val
+        move_pct = 0.0 if entry_price == 0 else (price - entry_price) / entry_price * 100.0
+        if move_pct >= target_pct:
+            return price, "target", ts_val.isoformat() if ts_val else None
+        if move_pct <= stop_pct:
+            return price, "stop", ts_val.isoformat() if ts_val else None
+        if (
+            start_time is not None
+            and ts_val is not None
+            and (ts_val - start_time) >= timedelta(minutes=time_cap_minutes)
+        ):
+            return price, "timeout", ts_val.isoformat()
+    return price, "timeout", None
+
+
+def run_backtest(
+    db,
+    *,
+    bars_by_symbol: Mapping[str, Sequence[Mapping[str, Any]]],
+    settings: LFSettings | None = None,
+) -> Dict[str, Any]:
+    settings = settings or load_settings(db)
+    balance = settings.starting_balance
+    equity_curve: List[Dict[str, Any]] = []
+    for symbol, bars in bars_by_symbol.items():
+        closes = [float(bar.get("close", 0.0)) for bar in bars]
+        if not closes:
+            continue
+        rsi_values = _rsi(closes)
+        window_high = None
+        window_low = None
+        window_end = None
+        open_trade_price = None
+        entry_index = None
+        for idx, bar in enumerate(bars):
+            ts_raw = bar.get("ts")
+            try:
+                ts = datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+            except ValueError:
+                ts = None
+            price = float(bar.get("close", 0.0))
+            if window_end is None:
+                window_end = idx + 5
+            if idx < (window_end or 0):
+                high = float(bar.get("high", price))
+                low = float(bar.get("low", price))
+                window_high = high if window_high is None else max(window_high, high)
+                window_low = low if window_low is None else min(window_low, low)
+                continue
+            vwap = float(bar.get("vwap", price))
+            rsi_ok = True
+            if settings.rsi_filter and idx < len(rsi_values):
+                rsi_ok = rsi_values[idx] >= 50.0
+            if open_trade_price is None and price > (window_high or price) and price >= vwap and rsi_ok:
+                open_trade_price = price
+                entry_index = idx
+                continue
+            if open_trade_price is not None and entry_index is not None:
+                segment = bars[entry_index : idx + 1]
+                exit_price, reason, _ = evaluate_exit(
+                    entry_price=open_trade_price,
+                    bars=segment,
+                    target_pct=settings.profit_target_pct,
+                    stop_pct=settings.max_adverse_pct,
+                    time_cap_minutes=settings.time_cap_minutes,
+                )
+                pnl = (exit_price - open_trade_price) * 100.0
+                balance += pnl
+                equity_curve.append(
+                    {
+                        "ts": ts.isoformat() if ts else None,
+                        "balance": balance,
+                        "symbol": symbol,
+                        "reason": reason,
+                        "net": pnl,
+                    }
+                )
+                open_trade_price = None
+                entry_index = None
+    summary = summarize_backtest(equity_curve, starting_balance=settings.starting_balance)
+    return {"equity_curve": equity_curve, "summary": summary}

--- a/services/scalper/shared.py
+++ b/services/scalper/shared.py
@@ -1,0 +1,163 @@
+"""Shared utilities for paper scalper engines."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean, pstdev
+from typing import Mapping, MutableMapping, Sequence
+
+TICK_SIZE = 0.01
+
+
+@dataclass(slots=True)
+class FeeModel:
+    """Simple fee model with per-contract and per-order charges."""
+
+    per_contract: float = 0.65
+    per_order: float = 0.0
+
+    def order_fees(self, qty: int) -> float:
+        contracts = max(0, int(qty))
+        return round(contracts * float(self.per_contract) + float(self.per_order), 2)
+
+
+def apply_slippage(mid_price: float, *, side: str, ticks: int = 1) -> float:
+    """Return a price adjusted by a number of ticks for a buy or sell."""
+
+    ticks = max(0, int(ticks))
+    mid = max(0.0, float(mid_price))
+    delta = ticks * TICK_SIZE
+    if side.lower() == "buy":
+        return round(max(TICK_SIZE, mid + delta), 2)
+    return round(max(TICK_SIZE, mid - delta), 2)
+
+
+def calculate_position_size(balance: float, pct_per_trade: float, mid_price: float) -> int:
+    pct = max(0.0, float(pct_per_trade)) / 100.0
+    mid = max(0.0, float(mid_price))
+    if pct <= 0 or mid <= 0:
+        return 0
+    notional = float(balance) * pct
+    cost_per_contract = mid * 100.0
+    qty = int(notional // cost_per_contract)
+    return max(0, qty)
+
+
+def summarize_backtest(trades: Sequence[Mapping[str, float]], *, starting_balance: float) -> Mapping[str, float]:
+    if not trades:
+        return {
+            "starting_balance": starting_balance,
+            "ending_balance": starting_balance,
+            "net_profit": 0.0,
+            "total_trades": 0,
+            "win_rate": 0.0,
+            "losses": 0,
+        }
+    ending_balance = trades[-1].get("balance", starting_balance)
+    total_trades = len(trades)
+    wins = sum(1 for trade in trades if float(trade.get("net", 0.0)) > 0)
+    losses = sum(1 for trade in trades if float(trade.get("net", 0.0)) < 0)
+    net_profit = float(ending_balance) - float(starting_balance)
+    win_rate = 0.0 if total_trades == 0 else round(wins / total_trades * 100.0, 2)
+    return {
+        "starting_balance": float(starting_balance),
+        "ending_balance": float(ending_balance),
+        "net_profit": net_profit,
+        "total_trades": total_trades,
+        "win_rate": win_rate,
+        "losses": losses,
+    }
+
+
+def compute_trade_metrics(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    starting_balance: float,
+) -> MutableMapping[str, float]:
+    trades = list(rows)
+    total_trades = len(trades)
+    if total_trades == 0:
+        return {
+            "win_rate": 0.0,
+            "avg_win": 0.0,
+            "avg_loss": 0.0,
+            "profit_factor": 0.0,
+            "sharpe": 0.0,
+            "max_drawdown": 0.0,
+            "trades_per_day": 0.0,
+        }
+
+    wins: list[float] = []
+    losses: list[float] = []
+    returns: list[float] = []
+    equity: list[float] = [float(starting_balance)]
+    trade_dates: set[str] = set()
+
+    balance = float(starting_balance)
+    for trade in sorted(trades, key=lambda row: str(row.get("exit_time") or row.get("entry_time"))):
+        net = float(trade.get("net_pl") or trade.get("realized_pl") or 0.0)
+        roi_pct = trade.get("roi_pct")
+        entry_time = trade.get("entry_time")
+        exit_time = trade.get("exit_time")
+        if isinstance(entry_time, str) and entry_time:
+            trade_dates.add(entry_time[:10])
+        if isinstance(exit_time, str) and exit_time:
+            trade_dates.add(exit_time[:10])
+        balance += net
+        equity.append(balance)
+        if net > 0:
+            wins.append(net)
+        elif net < 0:
+            losses.append(net)
+        if roi_pct is not None:
+            try:
+                returns.append(float(roi_pct) / 100.0)
+            except Exception:
+                pass
+        else:
+            if starting_balance > 0:
+                returns.append(net / float(starting_balance))
+
+    win_rate = len(wins) / total_trades * 100.0
+    avg_win = mean(wins) if wins else 0.0
+    avg_loss = mean(losses) if losses else 0.0
+    profit = sum(wins)
+    loss = abs(sum(losses))
+    profit_factor = 0.0 if loss == 0 else profit / loss
+    sharpe = _simple_sharpe_ratio(returns)
+    max_drawdown = _max_drawdown(equity)
+    trades_per_day = total_trades / max(1, len(trade_dates))
+    return {
+        "win_rate": round(win_rate, 2),
+        "avg_win": round(avg_win, 2),
+        "avg_loss": round(avg_loss, 2),
+        "profit_factor": round(profit_factor, 2),
+        "sharpe": round(sharpe, 2),
+        "max_drawdown": round(max_drawdown, 2),
+        "trades_per_day": round(trades_per_day, 2),
+    }
+
+
+def _simple_sharpe_ratio(returns: Sequence[float]) -> float:
+    clean = [float(r) for r in returns if isinstance(r, (int, float))]
+    if not clean:
+        return 0.0
+    avg = mean(clean)
+    if len(clean) == 1:
+        return avg / 1e-9
+    stdev = pstdev(clean)
+    if stdev == 0:
+        return 0.0
+    return avg / stdev * (len(clean) ** 0.5)
+
+
+def _max_drawdown(equity: Sequence[float]) -> float:
+    peak = float("-inf")
+    max_dd = 0.0
+    for value in equity:
+        val = float(value)
+        peak = max(peak, val)
+        if peak <= 0:
+            continue
+        dd = (val - peak) / peak * 100.0
+        max_dd = min(max_dd, dd)
+    return max_dd

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -980,10 +980,98 @@ select:focus,
   gap:1.5rem;
 }
 
+.paper-subtabs {
+  display:flex;
+  gap:0.5rem;
+  align-items:center;
+}
+
+.paper-subtab {
+  border:none;
+  background:rgba(255,255,255,0.05);
+  color:var(--muted);
+  padding:0.45rem 0.9rem;
+  border-radius:999px;
+  font-weight:600;
+  text-decoration:none;
+  cursor:pointer;
+  transition:background 0.2s ease, color 0.2s ease;
+}
+
+.paper-subtab:hover,
+.paper-subtab:focus {
+  color:var(--text);
+  background:rgba(94,160,255,0.15);
+}
+
+.paper-subtab.is-active {
+  background:var(--accent);
+  color:#06121f;
+  cursor:default;
+}
+
+.paper-subtab[disabled],
+.paper-subtab[aria-disabled="true"] {
+  opacity:0.4;
+  cursor:not-allowed;
+}
+
+
+.paper-section {
+  margin-bottom:2.5rem;
+}
+
+.paper-secondary-metrics {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(150px,1fr));
+  gap:0.75rem;
+  margin-top:0.5rem;
+}
+
+.paper-secondary-metrics .paper-metric strong {
+  font-size:1rem;
+}
+
+.visually-hidden {
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0,0,0,0);
+  white-space:nowrap;
+  border:0;
+}
+
 .paper-header-card {
   display:flex;
   flex-direction:column;
   gap:1rem;
+}
+
+.paper-lf-header {
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:1rem;
+  flex-wrap:wrap;
+}
+
+.paper-metrics {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(150px,1fr));
+  gap:0.75rem;
+}
+
+.paper-metric {
+  display:flex;
+  flex-direction:column;
+  gap:0.25rem;
+}
+
+.paper-metric strong {
+  font-size:1.35rem;
 }
 
 .paper-header-top {
@@ -1078,7 +1166,8 @@ select:focus,
   border:1px solid rgba(94,160,255,0.15);
 }
 
-#paper-equity-chart {
+#paper-equity-chart,
+#lf-equity-chart {
   width:100%;
   display:block;
 }

--- a/static/js/paper_scalper_lf.js
+++ b/static/js/paper_scalper_lf.js
@@ -1,0 +1,306 @@
+(function(){
+  const modes = [
+    {
+      key: 'lf',
+      statusSeedId: 'lf-status-seed',
+      equitySeedId: 'lf-equity-seed',
+      activitySeedId: 'lf-activity-seed',
+      metricsEl: document.getElementById('lf-metrics'),
+      secondaryEl: document.getElementById('lf-secondary-metrics'),
+      statusLine: document.getElementById('lf-status-line'),
+      rangeButtons: Array.from(document.querySelectorAll('.paper-range-btn[data-mode="lf"]')),
+      tableBody: document.getElementById('lf-activity-body'),
+      canvas: document.getElementById('lf-equity-chart'),
+      metricsMode: 'lf',
+      statusUrl: '/api/paper/scalper/lf/status',
+      equityUrl: (range) => `/api/paper/scalper/lf/equity.json?range=${encodeURIComponent(range)}`,
+      activityUrl: '/api/paper/scalper/lf/activity',
+    },
+    {
+      key: 'hf',
+      statusSeedId: 'hf-status-seed',
+      equitySeedId: 'hf-equity-seed',
+      activitySeedId: 'hf-activity-seed',
+      metricsEl: document.getElementById('hf-metrics'),
+      secondaryEl: document.getElementById('hf-secondary-metrics'),
+      statusLine: document.getElementById('hf-status-line'),
+      rangeButtons: Array.from(document.querySelectorAll('.paper-range-btn[data-mode="hf"]')),
+      tableBody: document.getElementById('hf-activity-body'),
+      canvas: document.getElementById('hf-equity-chart'),
+      metricsMode: 'hf',
+      statusUrl: '/api/paper/scalper/hf/status',
+      equityUrl: (range) => `/api/paper/scalper/hf/equity.json?range=${encodeURIComponent(range)}`,
+      activityUrl: '/api/paper/scalper/hf/activity',
+    },
+  ];
+
+  const currencyFmt = new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' });
+  const percentFmt = new Intl.NumberFormat(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+  const decimalFmt = new Intl.NumberFormat(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  const oneDecimalFmt = new Intl.NumberFormat(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+  const dateTimeFmt = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+
+  const chartState = new Map();
+
+  function readSeed(id) {
+    const el = document.getElementById(id);
+    if (!el) return null;
+    try {
+      return JSON.parse(el.textContent || 'null');
+    } catch (err) {
+      return null;
+    }
+  }
+
+  function formatStrikeExpiry(strike, expiry) {
+    const strikeNum = Number(strike);
+    const strikeText = Number.isFinite(strikeNum) ? `$${strikeNum.toFixed(2).replace(/\.00$/, '')}` : '—';
+    if (!expiry) {
+      return `${strikeText}-—`;
+    }
+    const maybeDate = new Date(expiry);
+    if (!Number.isNaN(maybeDate.valueOf())) {
+      const month = String(maybeDate.getMonth() + 1);
+      const day = String(maybeDate.getDate());
+      return `${strikeText}-${month}/${day}`;
+    }
+    return `${strikeText}-${expiry}`;
+  }
+
+  function formatTs(value) {
+    if (!value) return { text: '—', title: '' };
+    const dt = new Date(value);
+    if (Number.isNaN(dt.valueOf())) {
+      return { text: value, title: value };
+    }
+    return { text: dateTimeFmt.format(dt), title: dt.toISOString() };
+  }
+
+  function renderPrimaryMetrics(mode, data) {
+    const metricsEl = mode.metricsEl;
+    const statusLine = mode.statusLine;
+    if (!metricsEl || !data) return;
+    const equityEl = metricsEl.querySelector('[data-metric="equity"]');
+    const openEl = metricsEl.querySelector('[data-metric="open_positions"]');
+    const realizedEl = metricsEl.querySelector('[data-metric="realized"]');
+    const unrealizedEl = metricsEl.querySelector('[data-metric="unrealized"]');
+    const winEl = metricsEl.querySelector('[data-metric="win_rate"]');
+    const started = data.started_at;
+    if (equityEl) equityEl.textContent = currencyFmt.format(Number(data.account_equity || 0));
+    if (openEl) openEl.textContent = String(data.open_positions || 0);
+    if (realizedEl) realizedEl.textContent = currencyFmt.format(Number(data.realized_pl_day || 0));
+    if (unrealizedEl) unrealizedEl.textContent = currencyFmt.format(Number(data.unrealized_pl || 0));
+    if (winEl) winEl.textContent = `${percentFmt.format(Number(data.win_rate_pct || 0))}%`;
+    metricsEl.dataset.status = data.status || '';
+    metricsEl.dataset.started = started || '';
+    if ('halted' in data) {
+      metricsEl.dataset.halted = data.halted ? 'true' : 'false';
+    }
+    if (statusLine) {
+      const statusKey = (data.status || '').toLowerCase();
+      if (statusKey === 'active') {
+        if (data.halted) {
+          statusLine.textContent = 'Halted — awaiting manual restart';
+        } else if (started) {
+          const dt = new Date(started);
+          const label = Number.isNaN(dt.valueOf()) ? started : dateTimeFmt.format(dt);
+          statusLine.textContent = `Active since ${label}`;
+        } else {
+          statusLine.textContent = 'Active';
+        }
+      } else if (statusKey === 'halted') {
+        statusLine.textContent = 'Halted — risk guard triggered';
+      } else {
+        statusLine.textContent = 'Inactive';
+      }
+    }
+  }
+
+  function renderSecondaryMetrics(container, metrics) {
+    if (!container) return;
+    const data = metrics || {};
+    const avgWin = container.querySelector('[data-metric="avg_win"]');
+    const avgLoss = container.querySelector('[data-metric="avg_loss"]');
+    const profitFactor = container.querySelector('[data-metric="profit_factor"]');
+    const sharpe = container.querySelector('[data-metric="sharpe"]');
+    const maxDd = container.querySelector('[data-metric="max_drawdown"]');
+    const tradesDay = container.querySelector('[data-metric="trades_per_day"]');
+    if (avgWin) avgWin.textContent = currencyFmt.format(Number(data.avg_win || 0));
+    if (avgLoss) avgLoss.textContent = currencyFmt.format(Number(data.avg_loss || 0));
+    if (profitFactor) profitFactor.textContent = decimalFmt.format(Number(data.profit_factor || 0));
+    if (sharpe) sharpe.textContent = decimalFmt.format(Number(data.sharpe || 0));
+    if (maxDd) maxDd.textContent = `${percentFmt.format(Number(data.max_drawdown || 0))}%`;
+    if (tradesDay) tradesDay.textContent = oneDecimalFmt.format(Number(data.trades_per_day || 0));
+  }
+
+  function renderTable(body, rows) {
+    if (!body) return;
+    const data = Array.isArray(rows) ? rows : [];
+    if (!data.length) {
+      body.innerHTML = '<tr><td colspan="11" class="muted">No scalper trades yet.</td></tr>';
+      return;
+    }
+    const frag = document.createDocumentFragment();
+    data.forEach((row) => {
+      const tr = document.createElement('tr');
+      const entryMeta = formatTs(row.entry_time);
+      const exitMeta = formatTs(row.exit_time);
+      const roiValue = Number(row.roi_pct);
+      const roiCell = document.createElement('td');
+      if (Number.isFinite(roiValue)) {
+        roiCell.textContent = `${percentFmt.format(roiValue)}%`;
+        roiCell.className = roiValue >= 0 ? 'paper-roi-pos' : 'paper-roi-neg';
+      } else {
+        roiCell.textContent = '—';
+      }
+      const cells = [
+        row.date || '—',
+        row.ticker || '—',
+        row.call_put || '—',
+        formatStrikeExpiry(row.strike, row.expiry),
+        Number(row.qty) || 0,
+        entryMeta,
+        row.entry_price != null ? currencyFmt.format(Number(row.entry_price)) : '—',
+        exitMeta,
+        row.exit_price != null ? currencyFmt.format(Number(row.exit_price)) : '—',
+        roiCell,
+        currencyFmt.format(Number(row.fees || 0)),
+      ];
+      cells.forEach((cell) => {
+        let td;
+        if (cell instanceof HTMLElement) {
+          td = cell;
+        } else if (typeof cell === 'object' && cell && 'text' in cell) {
+          td = document.createElement('td');
+          td.textContent = cell.text;
+          if (cell.title) td.title = cell.title;
+        } else {
+          td = document.createElement('td');
+          td.textContent = String(cell);
+        }
+        tr.appendChild(td);
+      });
+      frag.appendChild(tr);
+    });
+    body.innerHTML = '';
+    body.appendChild(frag);
+  }
+
+  function renderChart(canvas, stateKey, points) {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dataset = Array.isArray(points) ? points : [];
+    const rect = canvas.getBoundingClientRect();
+    const width = rect.width || 600;
+    const height = rect.height || 260;
+    const ratio = window.devicePixelRatio || 1;
+    canvas.width = width * ratio;
+    canvas.height = height * ratio;
+    ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+    ctx.clearRect(0, 0, width, height);
+    if (!dataset.length) {
+      chartState.set(stateKey, { points: [], rendered: true, range: (chartState.get(stateKey) || {}).range || '1m' });
+      return;
+    }
+    const times = dataset.map((pt) => new Date(pt.ts || pt.time || Date.now()));
+    const balances = dataset.map((pt) => Number(pt.balance || 0));
+    const minTime = Math.min(...times.map((d) => d.valueOf()));
+    const maxTime = Math.max(...times.map((d) => d.valueOf()));
+    const minBal = Math.min(...balances);
+    const maxBal = Math.max(...balances);
+    const padX = 32;
+    const padY = 24;
+    const plotW = width - padX * 2;
+    const plotH = height - padY * 2;
+    const spanT = Math.max(1, maxTime - minTime);
+    const spanB = Math.max(1, maxBal - minBal);
+    ctx.beginPath();
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = 'rgba(94,160,255,0.9)';
+    dataset.forEach((pt, idx) => {
+      const t = times[idx].valueOf();
+      const b = balances[idx];
+      const x = padX + ((t - minTime) / spanT) * plotW;
+      const y = padY + (1 - (b - minBal) / spanB) * plotH;
+      if (idx === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+    const current = chartState.get(stateKey) || {};
+    chartState.set(stateKey, { points: dataset, rendered: true, range: current.range || '1m' });
+  }
+
+  function fetchStatus(mode) {
+    return fetch(mode.statusUrl, { credentials: 'same-origin' })
+      .then((resp) => (resp.ok ? resp.json() : Promise.reject()))
+      .then((payload) => {
+        renderPrimaryMetrics(mode, payload);
+        return payload;
+      })
+      .catch(() => null);
+  }
+
+  function fetchEquity(mode, range) {
+    const state = chartState.get(mode.key) || { range: '1m' };
+    const key = range || state.range || '1m';
+    return fetch(mode.equityUrl(key), { credentials: 'same-origin' })
+      .then((resp) => (resp.ok ? resp.json() : Promise.reject()))
+      .then((payload) => {
+        chartState.set(mode.key, { range: payload.range, rendered: true, points: payload.points || [] });
+        renderChart(mode.canvas, mode.key, payload.points || []);
+        return payload;
+      })
+      .catch(() => null);
+  }
+
+  function fetchActivity(mode) {
+    return fetch(mode.activityUrl, { credentials: 'same-origin' })
+      .then((resp) => (resp.ok ? resp.json() : Promise.reject()))
+      .then((payload) => {
+        renderTable(mode.tableBody, payload.rows || []);
+        return payload;
+      })
+      .catch(() => null);
+  }
+
+  function fetchMetrics(mode) {
+    return fetch(`/api/paper/scalper/metrics.json?mode=${encodeURIComponent(mode.metricsMode)}`, { credentials: 'same-origin' })
+      .then((resp) => (resp.ok ? resp.json() : Promise.reject()))
+      .then((payload) => {
+        renderSecondaryMetrics(mode.secondaryEl, payload.metrics || {});
+        return payload;
+      })
+      .catch(() => null);
+  }
+
+  modes.forEach((mode) => {
+    chartState.set(mode.key, { points: [], rendered: false, range: '1m' });
+    const statusSeed = readSeed(mode.statusSeedId) || {};
+    const equitySeedRaw = readSeed(mode.equitySeedId);
+    const equitySeed = Array.isArray(equitySeedRaw) ? equitySeedRaw : [];
+    const activitySeedRaw = readSeed(mode.activitySeedId);
+    const activitySeed = Array.isArray(activitySeedRaw) ? activitySeedRaw : [];
+
+    renderPrimaryMetrics(mode, statusSeed);
+    renderChart(mode.canvas, mode.key, equitySeed);
+    renderTable(mode.tableBody, activitySeed);
+    renderSecondaryMetrics(mode.secondaryEl, null);
+
+    mode.rangeButtons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        mode.rangeButtons.forEach((b) => b.classList.remove('is-active'));
+        btn.classList.add('is-active');
+        const key = btn.dataset.range || '1m';
+        const state = chartState.get(mode.key) || {};
+        chartState.set(mode.key, { ...state, range: key });
+        fetchEquity(mode, key);
+      });
+    });
+
+    fetchStatus(mode);
+    fetchEquity(mode, chartState.get(mode.key)?.range || '1m');
+    fetchActivity(mode);
+    fetchMetrics(mode);
+  });
+})();

--- a/templates/paper.html
+++ b/templates/paper.html
@@ -1,73 +1,206 @@
 {% extends 'base.html' %}
-{% block title %}Paper Trading — Petra Stock{% endblock %}
+{% block title %}Paper ▸ Scalper — Petra Stock{% endblock %}
 {% block content %}
   <div class="paper-container">
-    <div class="card paper-header-card">
-      <div class="paper-header-top">
-        <div class="paper-balance-group">
-          <p class="paper-label">Account Total</p>
-          {% set balance_value = summary.balance or 0.0 %}
-          <div id="paper-balance" data-balance="{{ balance_value }}">
-            ${{ '{:,.2f}'.format(balance_value) }}
+    <nav class="paper-subtabs" aria-label="Paper trading modes">
+      <a class="paper-subtab" href="/favorites">Favorites</a>
+      <a class="paper-subtab is-active" href="#lf-section">Low Frequency</a>
+      <a class="paper-subtab" href="#hf-section">High Frequency</a>
+    </nav>
+
+    <section id="lf-section" class="paper-section" aria-labelledby="lf-heading">
+      <div class="card paper-header-card">
+        <header class="paper-lf-header">
+          <div class="paper-metrics" id="lf-metrics" data-status="{{ scalper_lf_status.status }}" data-started="{{ scalper_lf_status.started_at or '' }}">
+            <h2 id="lf-heading" class="visually-hidden">Low-frequency scalper</h2>
+            <div class="paper-metric">
+              <p class="paper-label">Account Equity</p>
+              <strong data-metric="equity">$0.00</strong>
+            </div>
+            <div class="paper-metric">
+              <p class="paper-label">Open Positions</p>
+              <strong data-metric="open_positions">0</strong>
+            </div>
+            <div class="paper-metric">
+              <p class="paper-label">Realized P/L (day)</p>
+              <strong data-metric="realized">$0.00</strong>
+            </div>
+            <div class="paper-metric">
+              <p class="paper-label">Unrealized P/L</p>
+              <strong data-metric="unrealized">$0.00</strong>
+            </div>
+            <div class="paper-metric">
+              <p class="paper-label">Win%</p>
+              <strong data-metric="win_rate">0.0%</strong>
+            </div>
+          </div>
+          <div class="paper-range-toggle" role="group" aria-label="LF equity range">
+            {% set default_range = '1m' %}
+            {% for key,label in {'1d':'1D','1w':'1W','1m':'1M','1y':'1Y'}.items() %}
+              <button type="button" class="paper-range-btn {% if key == default_range %}is-active{% endif %}" data-mode="lf" data-range="{{ key }}">{{ label }}</button>
+            {% endfor %}
+          </div>
+        </header>
+        <p id="lf-status-line" class="paper-status-line">Inactive</p>
+        <div class="paper-chart-wrapper">
+          <canvas id="lf-equity-chart" height="260" aria-label="Low-frequency scalper equity chart"></canvas>
+        </div>
+        <div class="paper-secondary-metrics" id="lf-secondary-metrics">
+          <div class="paper-metric">
+            <p class="paper-label">Avg Win</p>
+            <strong data-metric="avg_win">$0.00</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Avg Loss</p>
+            <strong data-metric="avg_loss">$0.00</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Profit Factor</p>
+            <strong data-metric="profit_factor">0.00</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Sharpe</p>
+            <strong data-metric="sharpe">0.00</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Max Drawdown</p>
+            <strong data-metric="max_drawdown">0.0%</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Trades / Day</p>
+            <strong data-metric="trades_per_day">0.0</strong>
           </div>
         </div>
-        {% set roi_value = summary.roi_pct or 0.0 %}
-        <span id="paper-roi-chip" class="paper-roi-chip {% if roi_value >= 0 %}chip-pos{% else %}chip-neg{% endif %}">
-          {{ '%.2f'|format(roi_value) }}%
-        </span>
       </div>
-      <div class="paper-header-bottom">
-        <div class="paper-range-toggle" role="group" aria-label="Equity range">
-          {% set default_range = '1m' %}
-          {% for key,label in {'1d':'1D','1w':'1W','1m':'1M','1y':'1Y'}.items() %}
-            <button type="button" class="paper-range-btn {% if key == default_range %}is-active{% endif %}" data-range="{{ key }}">{{ label }}</button>
-          {% endfor %}
-        </div>
-        <div id="paper-status-line" class="paper-status-line">
-          {% if summary.status == 'active' %}
-            {% if summary.started_at %}
-              Active and running since {{ summary.started_at }}
-            {% else %}
-              Active and running
-            {% endif %}
-          {% else %}
-            Inactive
-          {% endif %}
-        </div>
-      </div>
-      <div class="paper-chart-wrapper">
-        <canvas id="paper-equity-chart" height="260" aria-label="Paper trading equity chart"></canvas>
-      </div>
-    </div>
 
-    <div class="card paper-table-card">
-      <div class="paper-table-toolbar">
-        <h2 class="paper-table-title">Activity</h2>
-        <a id="paper-export" class="btn btn-secondary btn-sm" href="/paper/trades?status=all&export=csv">Export CSV</a>
+      <div class="card paper-table-card">
+        <div class="paper-table-toolbar">
+          <h3 class="paper-table-title">LF Activity</h3>
+          <a id="lf-export" class="btn btn-secondary btn-sm" href="/api/paper/scalper/lf/activity.csv">Export CSV</a>
+        </div>
+        <div class="paper-table-scroll">
+          <table id="lf-activity-table" class="table paper-table" aria-describedby="lf-status-line">
+            <thead>
+              <tr>
+                <th scope="col">Date</th>
+                <th scope="col">Ticker</th>
+                <th scope="col">Call/Put</th>
+                <th scope="col">Strike-Expiry</th>
+                <th scope="col">Qty</th>
+                <th scope="col">Entry Time</th>
+                <th scope="col">Entry Price</th>
+                <th scope="col">Exit Time</th>
+                <th scope="col">Exit Price</th>
+                <th scope="col">ROI%</th>
+                <th scope="col">Fees</th>
+              </tr>
+            </thead>
+            <tbody id="lf-activity-body"></tbody>
+          </table>
+        </div>
       </div>
-      <div class="paper-table-scroll">
-        <table id="paper-trades-table" class="table paper-table" aria-describedby="paper-status-line">
-          <thead>
-            <tr>
-              <th>Ticker</th>
-              <th>Call/Put</th>
-              <th>Strike–Exp</th>
-              <th>Qty</th>
-              <th>Entry Time &amp; Date</th>
-              <th>Entry Price</th>
-              <th>Exit Time &amp; Date</th>
-              <th>Exit Price</th>
-              <th>ROI%</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody id="paper-trades-body"></tbody>
-        </table>
+    </section>
+
+    <section id="hf-section" class="paper-section" aria-labelledby="hf-heading">
+      <div class="card paper-header-card">
+        <header class="paper-lf-header">
+          <div class="paper-metrics" id="hf-metrics" data-status="{{ scalper_hf_status.status }}" data-started="{{ scalper_hf_status.started_at or '' }}" data-halted="{{ 'true' if scalper_hf_status.halted else 'false' }}">
+            <h2 id="hf-heading" class="visually-hidden">High-frequency scalper</h2>
+            <div class="paper-metric">
+              <p class="paper-label">Account Equity</p>
+              <strong data-metric="equity">$0.00</strong>
+            </div>
+            <div class="paper-metric">
+              <p class="paper-label">Open Positions</p>
+              <strong data-metric="open_positions">0</strong>
+            </div>
+            <div class="paper-metric">
+              <p class="paper-label">Realized P/L (day)</p>
+              <strong data-metric="realized">$0.00</strong>
+            </div>
+            <div class="paper-metric">
+              <p class="paper-label">Unrealized P/L</p>
+              <strong data-metric="unrealized">$0.00</strong>
+            </div>
+            <div class="paper-metric">
+              <p class="paper-label">Win%</p>
+              <strong data-metric="win_rate">0.0%</strong>
+            </div>
+          </div>
+          <div class="paper-range-toggle" role="group" aria-label="HF equity range">
+            {% set default_range = '1m' %}
+            {% for key,label in {'1d':'1D','1w':'1W','1m':'1M','1y':'1Y'}.items() %}
+              <button type="button" class="paper-range-btn {% if key == default_range %}is-active{% endif %}" data-mode="hf" data-range="{{ key }}">{{ label }}</button>
+            {% endfor %}
+          </div>
+        </header>
+        <p id="hf-status-line" class="paper-status-line">Inactive</p>
+        <div class="paper-chart-wrapper">
+          <canvas id="hf-equity-chart" height="260" aria-label="High-frequency scalper equity chart"></canvas>
+        </div>
+        <div class="paper-secondary-metrics" id="hf-secondary-metrics">
+          <div class="paper-metric">
+            <p class="paper-label">Avg Win</p>
+            <strong data-metric="avg_win">$0.00</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Avg Loss</p>
+            <strong data-metric="avg_loss">$0.00</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Profit Factor</p>
+            <strong data-metric="profit_factor">0.00</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Sharpe</p>
+            <strong data-metric="sharpe">0.00</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Max Drawdown</p>
+            <strong data-metric="max_drawdown">0.0%</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Trades / Day</p>
+            <strong data-metric="trades_per_day">0.0</strong>
+          </div>
+        </div>
       </div>
-    </div>
+
+      <div class="card paper-table-card">
+        <div class="paper-table-toolbar">
+          <h3 class="paper-table-title">HF Activity</h3>
+          <a id="hf-export" class="btn btn-secondary btn-sm" href="/api/paper/scalper/hf/activity.csv">Export CSV</a>
+        </div>
+        <div class="paper-table-scroll">
+          <table id="hf-activity-table" class="table paper-table" aria-describedby="hf-status-line">
+            <thead>
+              <tr>
+                <th scope="col">Date</th>
+                <th scope="col">Ticker</th>
+                <th scope="col">Call/Put</th>
+                <th scope="col">Strike-Expiry</th>
+                <th scope="col">Qty</th>
+                <th scope="col">Entry Time</th>
+                <th scope="col">Entry Price</th>
+                <th scope="col">Exit Time</th>
+                <th scope="col">Exit Price</th>
+                <th scope="col">ROI%</th>
+                <th scope="col">Fees</th>
+              </tr>
+            </thead>
+            <tbody id="hf-activity-body"></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
   </div>
-  <script type="application/json" id="paper-summary-seed">{{ summary|tojson|safe }}</script>
+  <script type="application/json" id="lf-status-seed">{{ scalper_lf_status|tojson|safe }}</script>
+  <script type="application/json" id="lf-equity-seed">{{ scalper_lf_equity|tojson|safe }}</script>
+  <script type="application/json" id="lf-activity-seed">{{ scalper_lf_activity|tojson|safe }}</script>
+  <script type="application/json" id="hf-status-seed">{{ scalper_hf_status|tojson|safe }}</script>
+  <script type="application/json" id="hf-equity-seed">{{ scalper_hf_equity|tojson|safe }}</script>
+  <script type="application/json" id="hf-activity-seed">{{ scalper_hf_activity|tojson|safe }}</script>
 {% endblock %}
 {% block extra_body %}
-  <script src="{{ url_for('static', path='js/paper.js') }}" defer></script>
+  <script src="{{ url_for('static', path='js/paper_scalper_lf.js') }}" defer></script>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -122,6 +122,23 @@
     gap: 1rem;
     margin-top: 1rem;
   }
+  .lf-settings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+  .session-inputs {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .session-inputs input[type="time"] {
+    width: 6rem;
+  }
+  .session-sep {
+    color: var(--muted);
+  }
   .paper-settings-actions {
     display: flex;
     gap: 0.5rem;
@@ -199,37 +216,156 @@
       <p class="note status-error" style="margin-top:.5rem;">SMTP configuration incomplete: {{ smtp_missing_label }}</p>
       {% endif %}
 
-      <div class="paper-settings-card" id="paper-settings-card" data-status="{{ paper_summary.status }}" data-started="{{ paper_summary.started_at or '' }}">
+      <div class="paper-settings-card" id="lf-settings-card" data-status="{{ scalper_status.status }}" data-started="{{ scalper_status.started_at or '' }}">
         <div class="paper-settings-header">
-          <h2 style="margin:0;">Paper Trading</h2>
-          <span id="paper-status-pill" class="paper-status-pill {% if paper_summary.status == 'active' %}active{% endif %}">
-            {% if paper_summary.status == 'active' %}Active{% else %}Inactive{% endif %}
+          <h2 style="margin:0;">Paper ▸ Scalper (Low Frequency)</h2>
+          <span id="lf-status-pill" class="paper-status-pill {% if scalper_status.status == 'active' %}active{% endif %}">
+            {% if scalper_status.status == 'active' %}Active{% else %}Inactive{% endif %}
           </span>
         </div>
-        <p class="note" style="margin:0;">Configure the simulated account balance and per-trade sizing limit.</p>
-        <div class="paper-settings-grid">
+        <p class="note" style="margin:0;">Controls for the simulated low-frequency scalper engine.</p>
+        <div class="lf-settings-grid">
           <label>Starting balance
-            <input name="paper_starting_balance" type="number" step="0.01" min="0" value="{{ '%.2f'|format(paper_settings.starting_balance) }}" />
+            <input name="scalper_starting_balance" type="number" step="0.01" min="0" value="{{ '%.2f'|format(scalper_settings.starting_balance) }}" />
           </label>
-          <label>Max % of account per trade
-            <input name="paper_max_pct" type="number" step="0.1" min="0.1" value="{{ '%.2f'|format(paper_settings.max_pct) }}" />
+          <label>% of equity per trade
+            <input name="scalper_pct_per_trade" type="number" step="0.1" min="0.5" max="10" value="{{ '%.1f'|format(scalper_settings.pct_per_trade) }}" />
+          </label>
+          <label>Daily trade cap
+            <input name="scalper_daily_cap" type="number" min="0" value="{{ scalper_settings.daily_trade_cap }}" />
+          </label>
+          <label>Tickers (CSV)
+            <input name="scalper_tickers" type="text" value="{{ scalper_settings.tickers }}" />
           </label>
         </div>
+        <div class="lf-settings-grid">
+          <label>Profit target %
+            <input name="scalper_target_pct" type="number" step="0.1" value="{{ '%.1f'|format(scalper_settings.profit_target_pct) }}" />
+          </label>
+          <label>Max adverse excursion %
+            <input name="scalper_stop_pct" type="number" step="0.1" value="{{ '%.1f'|format(scalper_settings.max_adverse_pct) }}" />
+          </label>
+          <label>Time cap (minutes)
+            <input name="scalper_time_cap" type="number" min="1" value="{{ scalper_settings.time_cap_minutes }}" />
+          </label>
+          <label>Session window
+            <div class="session-inputs">
+              <input name="scalper_session_start" type="time" value="{{ scalper_settings.session_start }}" />
+              <span class="session-sep">–</span>
+              <input name="scalper_session_end" type="time" value="{{ scalper_settings.session_end }}" />
+            </div>
+          </label>
+        </div>
+        <div class="lf-settings-grid">
+          <label>Per-contract fee
+            <input name="scalper_per_contract_fee" type="number" step="0.01" min="0" value="{{ '%.2f'|format(scalper_settings.per_contract_fee) }}" />
+          </label>
+          <label>Per-order fee
+            <input name="scalper_per_order_fee" type="number" step="0.01" min="0" value="{{ '%.2f'|format(scalper_settings.per_order_fee) }}" />
+          </label>
+          <label class="checkbox" style="align-items:center;">
+            <input type="checkbox" name="scalper_allow_premarket" value="1" {% if scalper_settings.allow_premarket %}checked{% endif %} />
+            <span>Allow pre-market</span>
+          </label>
+          <label class="checkbox" style="align-items:center;">
+            <input type="checkbox" name="scalper_allow_postmarket" value="1" {% if scalper_settings.allow_postmarket %}checked{% endif %} />
+            <span>Allow post-market</span>
+          </label>
+        </div>
+        <label class="checkbox" style="margin-top:0.5rem;">
+          <input type="checkbox" name="scalper_rsi_filter" value="1" {% if scalper_settings.rsi_filter %}checked{% endif %} />
+          <span>Enable RSI filter (>= 50)</span>
+        </label>
         <div class="paper-settings-actions">
-          <button type="button" class="btn btn-secondary" data-paper-action="start">Start</button>
-          <button type="button" class="btn btn-secondary" data-paper-action="stop">Stop</button>
-          <button type="button" class="btn btn-secondary" data-paper-action="restart">Restart</button>
+          <button type="button" class="btn btn-secondary" data-lf-action="start">Start</button>
+          <button type="button" class="btn btn-secondary" data-lf-action="stop">Stop</button>
+          <button type="button" class="btn btn-secondary" data-lf-action="restart">Restart</button>
         </div>
-        <p id="paper-settings-status" class="note" style="margin-top:0.5rem;">
-          {% if paper_summary.status == 'active' and paper_summary.started_at %}
-            Active and running since {{ paper_summary.started_at }}
-          {% elif paper_summary.status == 'active' %}
-            Active and running.
+        <p id="lf-settings-status" class="note" style="margin-top:0.5rem;">
+          {% if scalper_status.status == 'active' and scalper_status.started_at %}
+            Active since {{ scalper_status.started_at }}
+          {% elif scalper_status.status == 'active' %}
+            Active and monitoring.
           {% else %}
-            Paper trading is currently inactive.
+            Scalper engine is currently inactive.
           {% endif %}
         </p>
       </div>
+      <script type="application/json" id="lf-status-data">{{ scalper_status|tojson|safe }}</script>
+
+      <div class="paper-settings-card" id="hf-settings-card" data-status="{{ scalper_hf_status.status }}" data-started="{{ scalper_hf_status.started_at or '' }}">
+        <div class="paper-settings-header">
+          <h2 style="margin:0;">Paper ▸ Scalper (High Frequency)</h2>
+          <span id="hf-status-pill" class="paper-status-pill {% if scalper_hf_status.status == 'active' %}active{% endif %}">
+            {% if scalper_hf_status.status == 'active' %}Active{% elif scalper_hf_status.status == 'halted' %}Halted{% else %}Inactive{% endif %}
+          </span>
+        </div>
+        <p class="note" style="margin:0;">Controls for the simulated high-frequency scalper engine with momentum + volatility guardrails.</p>
+        <div class="lf-settings-grid">
+          <label>Starting balance
+            <input name="scalper_hf_starting_balance" type="number" step="0.01" min="0" value="{{ '%.2f'|format(scalper_hf_settings.starting_balance) }}" />
+          </label>
+          <label>% of equity per trade
+            <input name="scalper_hf_pct_per_trade" type="number" step="0.1" min="0.1" max="3" value="{{ '%.1f'|format(scalper_hf_settings.pct_per_trade) }}" />
+          </label>
+          <label>Daily trade cap
+            <input name="scalper_hf_daily_cap" type="number" min="0" value="{{ scalper_hf_settings.daily_trade_cap }}" />
+          </label>
+          <label>Tickers (CSV)
+            <input name="scalper_hf_tickers" type="text" value="{{ scalper_hf_settings.tickers }}" />
+          </label>
+        </div>
+        <div class="lf-settings-grid">
+          <label>Profit target %
+            <input name="scalper_hf_target_pct" type="number" step="0.1" value="{{ '%.1f'|format(scalper_hf_settings.profit_target_pct) }}" />
+          </label>
+          <label>Max adverse excursion %
+            <input name="scalper_hf_stop_pct" type="number" step="0.1" value="{{ '%.1f'|format(scalper_hf_settings.max_adverse_pct) }}" />
+          </label>
+          <label>Time cap (minutes)
+            <input name="scalper_hf_time_cap" type="number" min="1" value="{{ scalper_hf_settings.time_cap_minutes }}" />
+          </label>
+          <label>Cool-down (minutes)
+            <input name="scalper_hf_cooldown" type="number" min="0" value="{{ scalper_hf_settings.cooldown_minutes }}" />
+          </label>
+        </div>
+        <div class="lf-settings-grid">
+          <label>Max open positions
+            <input name="scalper_hf_max_positions" type="number" min="1" value="{{ scalper_hf_settings.max_open_positions }}" />
+          </label>
+          <label>Daily max drawdown %
+            <input name="scalper_hf_drawdown" type="number" step="0.1" value="{{ '%.1f'|format(scalper_hf_settings.daily_max_drawdown_pct) }}" />
+          </label>
+          <label>Volatility gate
+            <input name="scalper_hf_volatility_gate" type="number" step="0.1" min="0" value="{{ '%.1f'|format(scalper_hf_settings.volatility_gate) }}" />
+          </label>
+          <label>Per-contract fee
+            <input name="scalper_hf_per_contract_fee" type="number" step="0.01" min="0" value="{{ '%.2f'|format(scalper_hf_settings.per_contract_fee) }}" />
+          </label>
+        </div>
+        <div class="lf-settings-grid">
+          <label>Per-order fee
+            <input name="scalper_hf_per_order_fee" type="number" step="0.01" min="0" value="{{ '%.2f'|format(scalper_hf_settings.per_order_fee) }}" />
+          </label>
+        </div>
+        <div class="paper-settings-actions">
+          <button type="button" class="btn btn-secondary" data-hf-action="start">Start</button>
+          <button type="button" class="btn btn-secondary" data-hf-action="stop">Stop</button>
+          <button type="button" class="btn btn-secondary" data-hf-action="restart">Restart</button>
+        </div>
+        <p id="hf-settings-status" class="note" style="margin-top:0.5rem;">
+          {% if scalper_hf_status.status == 'active' and scalper_hf_status.started_at %}
+            Active since {{ scalper_hf_status.started_at }}{% if scalper_hf_status.halted %} (halt guard engaged){% endif %}
+          {% elif scalper_hf_status.status == 'halted' %}
+            Halted — risk guard engaged. Restart to resume.
+          {% elif scalper_hf_status.status == 'active' %}
+            Active and monitoring.
+          {% else %}
+            Scalper engine is currently inactive.
+          {% endif %}
+        </p>
+      </div>
+      <script type="application/json" id="hf-status-data">{{ scalper_hf_status|tojson|safe }}</script>
 
   <div class="actions">
     <button type="submit">Save</button>
@@ -357,12 +493,19 @@
       setTimeout(() => { toast.hidden = true; }, 2000);
     }
 
-    const paperStatusEl = document.getElementById('paper-settings-status');
-    const paperPill = document.getElementById('paper-status-pill');
-    const paperButtons = Array.from(document.querySelectorAll('[data-paper-action]'));
-    const paperDateFmt = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+    const lfStatusEl = document.getElementById('lf-settings-status');
+    const lfPill = document.getElementById('lf-status-pill');
+    const lfButtons = Array.from(document.querySelectorAll('[data-lf-action]'));
+    const lfSeedEl = document.getElementById('lf-status-data');
+    const lfDateFmt = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+    let lfSeed = {};
+    try {
+      lfSeed = JSON.parse(lfSeedEl?.textContent || '{}') || {};
+    } catch (err) {
+      lfSeed = {};
+    }
 
-    function renderPaperSummary(data) {
+    function renderLfStatus(data) {
       if (!data) return;
       const status = (data.status || '').toLowerCase();
       const startedRaw = data.started_at || '';
@@ -370,39 +513,39 @@
       if (startedRaw) {
         const parsed = new Date(startedRaw);
         if (!Number.isNaN(parsed.valueOf())) {
-          startedLabel = paperDateFmt.format(parsed);
+          startedLabel = lfDateFmt.format(parsed);
         }
       }
-      if (paperStatusEl) {
+      if (lfStatusEl) {
         if (status === 'active' && startedLabel) {
-          paperStatusEl.textContent = `Active and running since ${startedLabel}`;
+          lfStatusEl.textContent = `Active since ${startedLabel}`;
         } else if (status === 'active') {
-          paperStatusEl.textContent = 'Active and running.';
+          lfStatusEl.textContent = 'Active and monitoring.';
         } else {
-          paperStatusEl.textContent = 'Paper trading is currently inactive.';
+          lfStatusEl.textContent = 'Scalper engine is currently inactive.';
         }
       }
-      if (paperPill) {
+      if (lfPill) {
         if (status === 'active') {
-          paperPill.classList.add('active');
-          paperPill.textContent = 'Active';
+          lfPill.classList.add('active');
+          lfPill.textContent = 'Active';
         } else {
-          paperPill.classList.remove('active');
-          paperPill.textContent = 'Inactive';
+          lfPill.classList.remove('active');
+          lfPill.textContent = 'Inactive';
         }
       }
     }
 
-    function setPaperButtonsDisabled(disabled) {
-      paperButtons.forEach((btn) => {
+    function setLfButtonsDisabled(disabled) {
+      lfButtons.forEach((btn) => {
         btn.disabled = disabled;
       });
     }
 
-    function requestPaperAction(action) {
+    function requestLfAction(action) {
       if (!action) return;
-      setPaperButtonsDisabled(true);
-      fetch(`/paper/${action}`, {
+      setLfButtonsDisabled(true);
+      fetch(`/api/paper/scalper/lf/${action}`, {
         method: 'POST',
         credentials: 'same-origin',
       })
@@ -411,22 +554,118 @@
           return resp.json();
         })
         .then((payload) => {
-          renderPaperSummary(payload);
-          const msg = action === 'start' ? 'Paper trading started.' : action === 'stop' ? 'Paper trading stopped.' : 'Paper trading restarted.';
+          renderLfStatus(payload);
+          const msg = action === 'start'
+            ? 'Low-frequency scalper started.'
+            : action === 'stop'
+              ? 'Low-frequency scalper stopped.'
+              : 'Low-frequency scalper restarted.';
           showToast(msg, true);
         })
         .catch(() => {
-          showToast('Unable to update paper trading.', false);
+          showToast('Unable to update scalper engine.', false);
         })
-        .finally(() => setPaperButtonsDisabled(false));
+        .finally(() => setLfButtonsDisabled(false));
     }
 
-    paperButtons.forEach((btn) => {
+    lfButtons.forEach((btn) => {
       btn.addEventListener('click', () => {
-        const action = btn.dataset.paperAction;
-        requestPaperAction(action);
+        const action = btn.dataset.lfAction;
+        requestLfAction(action);
       });
     });
+
+    renderLfStatus(lfSeed);
+
+    const hfStatusEl = document.getElementById('hf-settings-status');
+    const hfPill = document.getElementById('hf-status-pill');
+    const hfButtons = Array.from(document.querySelectorAll('[data-hf-action]'));
+    const hfSeedEl = document.getElementById('hf-status-data');
+    let hfSeed = {};
+    try {
+      hfSeed = JSON.parse(hfSeedEl?.textContent || '{}') || {};
+    } catch (err) {
+      hfSeed = {};
+    }
+
+    function renderHfStatus(data) {
+      if (!data) return;
+      const status = (data.status || '').toLowerCase();
+      const startedRaw = data.started_at || '';
+      let startedLabel = startedRaw;
+      if (startedRaw) {
+        const parsed = new Date(startedRaw);
+        if (!Number.isNaN(parsed.valueOf())) {
+          startedLabel = lfDateFmt.format(parsed);
+        }
+      }
+      if (hfStatusEl) {
+        if (status === 'active' && data.halted) {
+          hfStatusEl.textContent = 'Halted — risk guard engaged. Restart to resume.';
+        } else if (status === 'active' && startedLabel) {
+          hfStatusEl.textContent = `Active since ${startedLabel}`;
+        } else if (status === 'active') {
+          hfStatusEl.textContent = 'Active and monitoring.';
+        } else if (status === 'halted') {
+          hfStatusEl.textContent = 'Halted — risk guard engaged. Restart to resume.';
+        } else {
+          hfStatusEl.textContent = 'Scalper engine is currently inactive.';
+        }
+      }
+      if (hfPill) {
+        if (status === 'active' && !data.halted) {
+          hfPill.classList.add('active');
+          hfPill.textContent = 'Active';
+        } else if (status === 'halted' || data.halted) {
+          hfPill.classList.remove('active');
+          hfPill.textContent = 'Halted';
+        } else {
+          hfPill.classList.remove('active');
+          hfPill.textContent = 'Inactive';
+        }
+      }
+    }
+
+    function setHfButtonsDisabled(disabled) {
+      hfButtons.forEach((btn) => {
+        btn.disabled = disabled;
+      });
+    }
+
+    function requestHfAction(action) {
+      if (!action) return;
+      setHfButtonsDisabled(true);
+      fetch(`/api/paper/scalper/hf/${action}`, {
+        method: 'POST',
+        credentials: 'same-origin',
+      })
+        .then((resp) => {
+          if (!resp.ok) throw new Error('request_failed');
+          return resp.json();
+        })
+        .then((payload) => {
+          renderHfStatus(payload);
+          const msg = action === 'start'
+            ? 'High-frequency scalper started.'
+            : action === 'stop'
+              ? 'High-frequency scalper stopped.'
+              : 'High-frequency scalper restarted.';
+          showToast(msg, true);
+        })
+        .catch(() => {
+          showToast('Unable to update high-frequency scalper.', false);
+        })
+        .finally(() => setHfButtonsDisabled(false));
+    }
+
+    hfButtons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const action = btn.dataset.hfAction;
+        requestHfAction(action);
+      });
+    });
+
+    renderHfStatus(hfSeed);
 
     const sendBtn = document.getElementById('send_test_alert');
     const testForm = document.getElementById('test-alert-form');

--- a/tests/test_scalper_hf_engine.py
+++ b/tests/test_scalper_hf_engine.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Iterator
+
+import pytest
+
+import db
+from db import get_db
+from services.scalper import hf_engine
+
+
+@pytest.fixture
+def db_cursor(tmp_path) -> Iterator:
+    db.DB_PATH = str(tmp_path / "scalper_hf.db")
+    db.init_db()
+    gen = get_db()
+    cursor = next(gen)
+    try:
+        yield cursor
+    finally:
+        try:
+            cursor.connection.close()
+        except Exception:
+            pass
+        try:
+            gen.close()
+        except Exception:
+            pass
+
+
+def test_hf_signal_controls(db_cursor):
+    start = datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc)
+    hf_engine.restart_engine(db_cursor, now=start)
+    settings = hf_engine.update_settings(
+        db_cursor,
+        starting_balance=50000,
+        pct_per_trade=2,
+        daily_trade_cap=5,
+        tickers=["SPY", "QQQ"],
+        profit_target_pct=4,
+        max_adverse_pct=-2,
+        time_cap_minutes=5,
+        cooldown_minutes=2,
+        max_open_positions=2,
+        daily_max_drawdown_pct=-3,
+        per_contract_fee=0.65,
+        per_order_fee=0.0,
+        volatility_gate=3.0,
+    )
+    # Insufficient momentum should gate the trade.
+    blocked = hf_engine.open_trade(
+        db_cursor,
+        ticker="SPY",
+        option_type="CALL",
+        strike=450,
+        expiry="2024-01-19",
+        mid_price=2.5,
+        entry_time=start,
+        momentum_score=0.1,
+        vwap=2.5,
+        ema9=2.5,
+        volatility=1.0,
+        liquidity=1.0,
+        settings=settings,
+    )
+    assert blocked is None
+
+    entry_one = start + timedelta(minutes=1)
+    trade_one = hf_engine.open_trade(
+        db_cursor,
+        ticker="SPY",
+        option_type="CALL",
+        strike=450,
+        expiry="2024-01-19",
+        mid_price=2.4,
+        entry_time=entry_one,
+        momentum_score=1.1,
+        vwap=2.4,
+        ema9=2.35,
+        volatility=1.0,
+        liquidity=0.9,
+        settings=settings,
+    )
+    assert trade_one is not None
+
+    entry_two = entry_one + timedelta(minutes=1)
+    trade_two = hf_engine.open_trade(
+        db_cursor,
+        ticker="QQQ",
+        option_type="CALL",
+        strike=380,
+        expiry="2024-01-19",
+        mid_price=1.8,
+        entry_time=entry_two,
+        momentum_score=1.2,
+        vwap=1.81,
+        ema9=1.79,
+        volatility=1.1,
+        liquidity=0.8,
+        settings=settings,
+    )
+    assert trade_two is not None
+
+    # Third trade should be blocked by max open positions.
+    trade_three = hf_engine.open_trade(
+        db_cursor,
+        ticker="TSLA",
+        option_type="PUT",
+        strike=250,
+        expiry="2024-01-19",
+        mid_price=3.0,
+        entry_time=entry_two,
+        momentum_score=1.3,
+        vwap=3.0,
+        ema9=2.95,
+        volatility=1.0,
+        liquidity=0.7,
+        settings=settings,
+    )
+    assert trade_three is None
+
+    exit_one = entry_one + timedelta(minutes=2)
+    closed_one = hf_engine.close_trade(
+        db_cursor,
+        trade_one,
+        mid_price=2.6,
+        exit_time=exit_one,
+        liquidity=0.8,
+        settings=settings,
+    )
+    assert closed_one is not None
+
+    # Cool-down should block immediate re-entry.
+    cooldown_block = hf_engine.open_trade(
+        db_cursor,
+        ticker="MSFT",
+        option_type="CALL",
+        strike=330,
+        expiry="2024-01-19",
+        mid_price=1.5,
+        entry_time=exit_one,
+        momentum_score=1.1,
+        vwap=1.5,
+        ema9=1.48,
+        volatility=1.0,
+        liquidity=0.9,
+        settings=settings,
+    )
+    assert cooldown_block is None
+
+    # Force a drawdown breach and ensure engine halts.
+    aggressive_settings = hf_engine.update_settings(
+        db_cursor,
+        starting_balance=settings.starting_balance,
+        pct_per_trade=5,
+        daily_trade_cap=settings.daily_trade_cap,
+        tickers=settings.tickers.split(","),
+        profit_target_pct=settings.profit_target_pct,
+        max_adverse_pct=settings.max_adverse_pct,
+        time_cap_minutes=settings.time_cap_minutes,
+        cooldown_minutes=settings.cooldown_minutes,
+        max_open_positions=settings.max_open_positions,
+        daily_max_drawdown_pct=-0.5,
+        per_contract_fee=settings.per_contract_fee,
+        per_order_fee=settings.per_order_fee,
+        volatility_gate=settings.volatility_gate,
+    )
+    exit_two = entry_two + timedelta(minutes=3)
+    hf_engine.close_trade(
+        db_cursor,
+        trade_two,
+        mid_price=1.4,
+        exit_time=exit_two,
+        liquidity=0.4,
+        settings=aggressive_settings,
+    )
+    breach_attempt = hf_engine.open_trade(
+        db_cursor,
+        ticker="AMD",
+        option_type="CALL",
+        strike=180,
+        expiry="2024-01-19",
+        mid_price=1.2,
+        entry_time=exit_two + timedelta(minutes=3),
+        momentum_score=1.5,
+        vwap=1.21,
+        ema9=1.19,
+        volatility=1.0,
+        liquidity=0.6,
+        settings=aggressive_settings,
+    )
+    assert breach_attempt is None
+    halted_status = hf_engine.status_payload(db_cursor)
+    assert halted_status.get("status") == "halted"
+    assert halted_status.get("halted") is True
+
+
+def test_hf_slippage_widening(db_cursor):
+    hf_engine.restart_engine(db_cursor, now=datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc))
+    settings = hf_engine.update_settings(
+        db_cursor,
+        starting_balance=100000,
+        pct_per_trade=1,
+        daily_trade_cap=10,
+        tickers=["SPY"],
+        profit_target_pct=4,
+        max_adverse_pct=-2,
+        time_cap_minutes=5,
+        cooldown_minutes=0,
+        max_open_positions=3,
+        daily_max_drawdown_pct=-10,
+        per_contract_fee=0.0,
+        per_order_fee=0.0,
+        volatility_gate=5.0,
+    )
+    entry_time = datetime(2024, 1, 2, 14, 35, tzinfo=timezone.utc)
+    trade_liquid = hf_engine.open_trade(
+        db_cursor,
+        ticker="SPY",
+        option_type="CALL",
+        strike=450,
+        expiry="2024-01-19",
+        mid_price=1.50,
+        entry_time=entry_time,
+        momentum_score=1.2,
+        vwap=1.50,
+        ema9=1.49,
+        volatility=1.0,
+        liquidity=1.0,
+        settings=settings,
+    )
+    assert trade_liquid is not None
+    low_liq_time = entry_time + timedelta(minutes=1)
+    trade_thin = hf_engine.open_trade(
+        db_cursor,
+        ticker="QQQ",
+        option_type="CALL",
+        strike=380,
+        expiry="2024-01-19",
+        mid_price=1.50,
+        entry_time=low_liq_time,
+        momentum_score=1.3,
+        vwap=1.50,
+        ema9=1.49,
+        volatility=1.0,
+        liquidity=0.1,
+        settings=settings,
+    )
+    assert trade_thin is not None
+    row_liquid = db_cursor.execute(
+        "SELECT entry_price FROM scalper_hf_activity WHERE id=?",
+        (trade_liquid,),
+    ).fetchone()
+    row_thin = db_cursor.execute(
+        "SELECT entry_price FROM scalper_hf_activity WHERE id=?",
+        (trade_thin,),
+    ).fetchone()
+    assert row_liquid and row_thin
+    assert float(row_thin["entry_price"]) > float(row_liquid["entry_price"])
+
+
+def test_hf_metrics_snapshot(db_cursor):
+    hf_engine.restart_engine(db_cursor, now=datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc))
+    settings = hf_engine.update_settings(
+        db_cursor,
+        starting_balance=100000,
+        pct_per_trade=1,
+        daily_trade_cap=10,
+        tickers=["SPY", "QQQ"],
+        profit_target_pct=4,
+        max_adverse_pct=-2,
+        time_cap_minutes=5,
+        cooldown_minutes=0,
+        max_open_positions=3,
+        daily_max_drawdown_pct=-10,
+        per_contract_fee=0.0,
+        per_order_fee=0.0,
+        volatility_gate=5.0,
+    )
+    entry = datetime(2024, 1, 2, 14, 31, tzinfo=timezone.utc)
+    t1 = hf_engine.open_trade(
+        db_cursor,
+        ticker="SPY",
+        option_type="CALL",
+        strike=450,
+        expiry="2024-01-19",
+        mid_price=2.0,
+        entry_time=entry,
+        momentum_score=1.0,
+        vwap=2.0,
+        ema9=1.99,
+        volatility=1.0,
+        liquidity=0.8,
+        settings=settings,
+    )
+    hf_engine.close_trade(
+        db_cursor,
+        t1,
+        mid_price=2.4,
+        exit_time=entry + timedelta(minutes=2),
+        liquidity=0.8,
+        settings=settings,
+    )
+    t2 = hf_engine.open_trade(
+        db_cursor,
+        ticker="QQQ",
+        option_type="CALL",
+        strike=380,
+        expiry="2024-01-19",
+        mid_price=1.5,
+        entry_time=entry + timedelta(minutes=3),
+        momentum_score=1.1,
+        vwap=1.5,
+        ema9=1.48,
+        volatility=1.0,
+        liquidity=0.9,
+        settings=settings,
+    )
+    hf_engine.close_trade(
+        db_cursor,
+        t2,
+        mid_price=1.2,
+        exit_time=entry + timedelta(minutes=5),
+        liquidity=0.5,
+        settings=settings,
+    )
+    metrics = hf_engine.metrics_snapshot(db_cursor)
+    assert metrics["win_rate"] == pytest.approx(50.0)
+    assert metrics["avg_win"] > 0
+    assert metrics["avg_loss"] < 0
+    assert metrics["profit_factor"] > 0
+    assert metrics["trades_per_day"] >= 1.0
+
+
+def test_hf_backtest_smoke(db_cursor):
+    bars = {
+        "SPY": [
+            {"ts": "2024-01-02T14:30:00Z", "open": 470.0, "high": 471.0, "low": 469.5, "close": 470.5, "vwap": 470.3, "volume": 120000},
+            {"ts": "2024-01-02T14:31:00Z", "open": 470.5, "high": 471.5, "low": 470.2, "close": 471.2, "vwap": 470.7, "volume": 98000},
+            {"ts": "2024-01-02T14:32:00Z", "open": 471.2, "high": 472.0, "low": 471.0, "close": 471.8, "vwap": 471.0, "volume": 86000},
+            {"ts": "2024-01-02T14:33:00Z", "open": 471.8, "high": 472.4, "low": 471.5, "close": 472.2, "vwap": 471.4, "volume": 79000},
+            {"ts": "2024-01-02T14:34:00Z", "open": 472.2, "high": 472.6, "low": 471.9, "close": 472.5, "vwap": 471.7, "volume": 72000},
+        ]
+    }
+    results = hf_engine.run_backtest(db_cursor, bars_by_symbol=bars)
+    assert "equity_curve" in results
+    assert "summary" in results
+    assert isinstance(results["equity_curve"], list)
+    assert set(results["summary"].keys()) >= {"starting_balance", "ending_balance", "net_profit", "total_trades", "win_rate"}

--- a/tests/test_scalper_lf_engine.py
+++ b/tests/test_scalper_lf_engine.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterator
+
+import pytest
+
+import db
+from db import get_db
+from services.scalper import lf_engine
+
+
+@pytest.fixture
+def db_cursor(tmp_path) -> Iterator:
+    db.DB_PATH = str(tmp_path / "scalper.db")
+    db.init_db()
+    gen = get_db()
+    cursor = next(gen)
+    try:
+        yield cursor
+    finally:
+        try:
+            cursor.connection.close()
+        except Exception:
+            pass
+        try:
+            gen.close()
+        except Exception:
+            pass
+
+
+def test_position_sizing_formula():
+    qty = lf_engine.calculate_position_size(balance=100000, pct_per_trade=3, mid_price=2.5)
+    assert qty == 12  # floor((100000 * 0.03) / (2.5 * 100))
+
+
+def test_fill_and_fees_model(db_cursor):
+    lf_engine.restart_engine(db_cursor, now=datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc))
+    settings = lf_engine.load_settings(db_cursor)
+    trade_id = lf_engine.open_trade(
+        db_cursor,
+        ticker="SPY",
+        option_type="CALL",
+        strike=450,
+        expiry="2024-01-19",
+        mid_price=2.0,
+        entry_time=datetime(2024, 1, 2, 15, 0, tzinfo=timezone.utc),
+        settings=settings,
+    )
+    assert trade_id is not None
+    closed = lf_engine.close_trade(
+        db_cursor,
+        trade_id,
+        mid_price=2.5,
+        exit_time=datetime(2024, 1, 2, 15, 10, tzinfo=timezone.utc),
+        settings=settings,
+        reason="target",
+    )
+    assert closed is not None
+    assert closed.entry_price == pytest.approx(2.01)
+    assert closed.exit_price == pytest.approx(2.49)
+    # qty computed based on 3% sizing default -> floor((100000*0.03)/(2*100)) == 15
+    qty = lf_engine.calculate_position_size(100000, settings.pct_per_trade, 2.0)
+    expected_fees = round((qty * settings.per_contract_fee + settings.per_order_fee) * 2, 2)
+    assert closed.fees == pytest.approx(expected_fees)
+
+
+def test_exit_conditions_evaluate_target_stop_time():
+    entry = 2.0
+    bars = [
+        {"ts": "2024-01-02T14:31:00Z", "close": 2.02},
+        {"ts": "2024-01-02T14:32:00Z", "close": 2.12},
+        {"ts": "2024-01-02T14:33:00Z", "close": 1.92},
+    ]
+    price, reason, ts = lf_engine.evaluate_exit(
+        entry_price=entry,
+        bars=bars,
+        target_pct=4.0,
+        stop_pct=-3.0,
+        time_cap_minutes=10,
+    )
+    assert reason == "target"
+    assert price == pytest.approx(2.12)
+    assert ts is not None
+
+    timeout_price, timeout_reason, _ = lf_engine.evaluate_exit(
+        entry_price=entry,
+        bars=[{"ts": "2024-01-02T14:31:00Z", "close": 2.01}],
+        target_pct=10.0,
+        stop_pct=-10.0,
+        time_cap_minutes=0,
+    )
+    assert timeout_reason == "timeout"
+    assert timeout_price == pytest.approx(2.01)
+
+
+def test_daily_trade_cap_and_dedupe(db_cursor, caplog):
+    caplog.set_level("INFO")
+    settings = lf_engine.update_settings(
+        db_cursor,
+        starting_balance=100000,
+        pct_per_trade=3,
+        daily_trade_cap=1,
+        tickers=["SPY"],
+        profit_target_pct=6,
+        max_adverse_pct=-3,
+        time_cap_minutes=15,
+        session_start="09:30",
+        session_end="16:00",
+        allow_premarket=False,
+        allow_postmarket=False,
+        per_contract_fee=0.65,
+        per_order_fee=0.0,
+        rsi_filter=False,
+    )
+    lf_engine.restart_engine(db_cursor, now=datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc))
+    first_id = lf_engine.open_trade(
+        db_cursor,
+        ticker="SPY",
+        option_type="CALL",
+        strike=450,
+        expiry="2024-01-19",
+        mid_price=2.0,
+        entry_time=datetime(2024, 1, 2, 15, 0, tzinfo=timezone.utc),
+        settings=settings,
+    )
+    assert first_id is not None
+    duplicate = lf_engine.open_trade(
+        db_cursor,
+        ticker="SPY",
+        option_type="CALL",
+        strike=450,
+        expiry="2024-01-19",
+        mid_price=2.0,
+        entry_time=datetime(2024, 1, 2, 15, 5, tzinfo=timezone.utc),
+        settings=settings,
+    )
+    assert duplicate is None
+    cap_hit = lf_engine.open_trade(
+        db_cursor,
+        ticker="QQQ",
+        option_type="CALL",
+        strike=380,
+        expiry="2024-01-19",
+        mid_price=1.5,
+        entry_time=datetime(2024, 1, 2, 15, 6, tzinfo=timezone.utc),
+        settings=settings,
+    )
+    assert cap_hit is None
+
+
+def test_status_lifecycle(db_cursor):
+    stopped = lf_engine.stop_engine(db_cursor)
+    assert stopped.status == "inactive"
+    started = lf_engine.start_engine(db_cursor, now=datetime(2024, 1, 2, tzinfo=timezone.utc))
+    assert started.status == "active"
+    restarted = lf_engine.restart_engine(db_cursor, now=datetime(2024, 1, 3, tzinfo=timezone.utc))
+    assert restarted.started_at.endswith("03T00:00:00+00:00")
+
+
+@pytest.mark.asyncio
+async def test_adapter_fallback(monkeypatch):
+    calls: list[str] = []
+
+    async def fail_quote(symbol: str):
+        calls.append("schwab")
+        raise RuntimeError("boom")
+
+    async def success_quote(symbol: str):
+        calls.append("yfinance")
+        return {"symbol": symbol, "price": 1.23, "source": "yfinance"}
+
+    monkeypatch.setattr(lf_engine, "_fetch_schwab_quote", fail_quote)
+    monkeypatch.setattr(lf_engine, "_fetch_yfinance_quote", success_quote)
+
+    quote = await lf_engine.fetch_quote("SPY")
+    assert quote["source"] == "yfinance"
+    assert calls == ["schwab", "yfinance"]
+
+
+def test_backtest_smoke(db_cursor):
+    bars = {
+        "SPY": [
+            {"ts": "2024-01-02T14:30:00Z", "open": 470.0, "high": 471.0, "low": 469.5, "close": 470.5, "vwap": 470.3},
+            {"ts": "2024-01-02T14:31:00Z", "open": 470.5, "high": 471.5, "low": 470.2, "close": 471.2, "vwap": 470.7},
+            {"ts": "2024-01-02T14:32:00Z", "open": 471.2, "high": 472.0, "low": 471.0, "close": 471.8, "vwap": 471.0},
+            {"ts": "2024-01-02T14:33:00Z", "open": 471.8, "high": 472.4, "low": 471.5, "close": 472.2, "vwap": 471.4},
+            {"ts": "2024-01-02T14:34:00Z", "open": 472.2, "high": 472.6, "low": 471.9, "close": 472.5, "vwap": 471.7},
+            {"ts": "2024-01-02T14:35:00Z", "open": 472.5, "high": 473.0, "low": 472.2, "close": 472.9, "vwap": 472.0},
+            {"ts": "2024-01-02T14:36:00Z", "open": 472.9, "high": 473.4, "low": 472.6, "close": 472.7, "vwap": 472.3},
+        ]
+    }
+    results = lf_engine.run_backtest(db_cursor, bars_by_symbol=bars)
+    assert "equity_curve" in results
+    assert "summary" in results
+    assert isinstance(results["equity_curve"], list)
+    assert set(results["summary"].keys()) >= {"starting_balance", "ending_balance", "net_profit", "total_trades", "win_rate"}
+
+
+def test_activity_csv_schema(db_cursor):
+    lf_engine.restart_engine(db_cursor, now=datetime(2024, 1, 2, tzinfo=timezone.utc))
+    settings = lf_engine.load_settings(db_cursor)
+    trade_id = lf_engine.open_trade(
+        db_cursor,
+        ticker="TSLA",
+        option_type="PUT",
+        strike=250,
+        expiry="2024-01-19",
+        mid_price=1.25,
+        entry_time=datetime(2024, 1, 2, 15, 0, tzinfo=timezone.utc),
+        settings=settings,
+    )
+    assert trade_id is not None
+    lf_engine.close_trade(
+        db_cursor,
+        trade_id,
+        mid_price=1.5,
+        exit_time=datetime(2024, 1, 2, 15, 5, tzinfo=timezone.utc),
+        settings=settings,
+        reason="target",
+    )
+    csv_text, filename = lf_engine.export_activity_csv(db_cursor)
+    assert filename == "scalper_lf_activity.csv"
+    rows = [line.split(",") for line in csv_text.strip().splitlines()]
+    assert rows[0] == [
+        "Date",
+        "Ticker",
+        "Call/Put",
+        "Strike-Expiry",
+        "Qty",
+        "Entry Time",
+        "Entry Price",
+        "Exit Time",
+        "Exit Price",
+        "ROI%",
+        "Fees",
+    ]
+    assert any("Fees" in header for header in rows[0])


### PR DESCRIPTION
## Summary
- add a shared scalper utility module for fees, sizing, metrics, and backtest summaries
- implement the high-frequency scalper engine with risk guards, exports, and backtest support while refactoring the LF engine to reuse shared helpers
- extend paper/settings UIs and routes with HF endpoints, shared metrics, and dual-mode charts/tables plus new HF tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68da905d0dd08329b697d7e76f9c27e2