### PR TITLE
Ensure Schwab settings load from env file

### DIFF
--- a/config.py
+++ b/config.py
@@ -81,6 +81,7 @@ def _load_environment_from_file(path: Path) -> None:
 
         lexer = shlex.shlex(raw_line, posix=True)
         lexer.whitespace_split = True
+        lexer.commenters = ""
         try:
             tokens = list(lexer)
         except ValueError:
@@ -95,7 +96,9 @@ def _load_environment_from_file(path: Path) -> None:
             if not name:
                 continue
             value = value.strip()
-            os.environ.setdefault(name, value)
+            current = os.getenv(name)
+            if current is None or (isinstance(current, str) and not current.strip()):
+                os.environ[name] = value
 
 
 def _load_environment() -> None:

--- a/tests/test_env_integration.py
+++ b/tests/test_env_integration.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_app_uses_env_file_for_schwab_settings(tmp_path):
+    env_file = tmp_path / "petra.env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "DATA_PROVIDER=schwab",
+                "SCHWAB_CLIENT_ID=client-from-file",
+                "SCHWAB_CLIENT_SECRET=secret#with-comment-char",
+                "SCHWAB_REDIRECT_URI=https://example.com/callback",
+                "SCHWAB_ACCOUNT_ID=00001234",
+                "SCHWAB_REFRESH_TOKEN=refresh-from-file",
+                "SCHWAB_TOKENS_PATH=/tmp/schwab_tokens.json",
+                "",
+            ]
+        )
+    )
+
+    repo_root = Path(__file__).resolve().parents[1]
+    pythonpath = os.pathsep.join(
+        filter(None, [str(repo_root), os.environ.get("PYTHONPATH", "")])
+    )
+
+    script = r"""
+import json
+import os
+import sys
+
+env_file = sys.argv[1]
+for key in list(os.environ):
+    if key.startswith("SCHWAB_"):
+        os.environ.pop(key, None)
+
+os.environ.setdefault("DATA_PROVIDER", "schwab")
+os.environ["PETRA_ENV_FILE"] = env_file
+
+import main  # noqa: F401 - triggers application import
+from config import settings
+
+payload = {
+    "client_id": settings.schwab_client_id,
+    "client_secret": settings.schwab_client_secret,
+    "redirect_uri": settings.schwab_redirect_uri,
+    "account_id": settings.schwab_account_id,
+    "refresh_token": settings.schwab_refresh_token,
+    "tokens_path": os.getenv("SCHWAB_TOKENS_PATH"),
+}
+
+print(json.dumps(payload))
+"""
+
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONPATH": pythonpath,
+        "PYTHONUNBUFFERED": "1",
+        "DATA_PROVIDER": "schwab",
+        "PETRA_ENV_FILE": str(env_file),
+    }
+
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(env_file)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=repo_root,
+    )
+
+    output_line = result.stdout.strip().splitlines()[-1]
+    data = json.loads(output_line)
+
+    assert data == {
+        "client_id": "client-from-file",
+        "client_secret": "secret#with-comment-char",
+        "redirect_uri": "https://example.com/callback",
+        "account_id": "00001234",
+        "refresh_token": "refresh-from-file",
+        "tokens_path": "/tmp/schwab_tokens.json",
+    }


### PR DESCRIPTION
## Summary
- allow the environment loader to treat values with comment characters and backfill empty variables from env files
- cover Schwab configuration loading with an integration test that boots the FastAPI app in a subprocess using a temp env file

## Testing
- pytest tests/test_env_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68e0ba821044832994c2d6ec42da453b