### PR TITLE
Fix HTTP client in-flight cache per event loop

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -44,3 +44,15 @@ as needed.
   affecting email alerts.
 - The minute scheduler now triggers the autoscan batch every 15 minutes while
   XNYS is open so alerts dispatch automatically during the trading session.
+
+## Testing notes
+- `tests/test_data_provider.py::test_fetch_bars_uses_schwab` currently fails
+  because the Schwab stub in the test returns an empty DataFrame, so the data
+  provider falls back to yfinance despite the test expecting a Schwab hit.
+- `tests/test_data_provider.py::test_fetch_bars_fallbacks_to_yfinance` also
+  fails because the fallback path hydrates from the DB cache when the simulated
+  yfinance fetch returns zero rows. Both failures reproduce on the main branch
+  and are unrelated to the HTTP client event loop caching changes.
+- `tests/test_scanner_safeguards.py::test_gap_fill_inside_event_loop` still
+  fails due to the same DB-only gap-fill behavior above; the regression predates
+  the HTTP client fix. The remainder of the scanner safeguards suite passes.


### PR DESCRIPTION
## Summary
- key the HTTP client's in-flight task cache by event loop id to avoid reusing tasks across loops
- ensure the request helper only awaits tasks created on the current loop and cleans up empty cache entries
- document the pre-existing data provider and scanner safeguard test failures that reproduce on main

## Testing
- pytest tests/test_http_client_backoff.py -q
- pytest tests/test_data_provider.py::test_fetch_bars_uses_schwab -q *(fails: Schwab stub returns empty frame so provider falls back to yfinance)*
- pytest tests/test_data_provider.py::test_fetch_bars_fallbacks_to_yfinance -q *(fails: fallback path hydrates from DB cache and never sets provider to yfinance)*
- pytest tests/test_scanner_safeguards.py -q *(fails: gap-fill test expects non-empty frame but DB-only code returns empty, also fails on main)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ce78a8588329b68ace444517225e