### PR TITLE
Add favorites paper simulator scaffold

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,5 +1,6 @@
 """Service layer package with shared configuration exports."""
 
 from config import settings as settings
+from . import favorites_sim as favorites_sim
 
-__all__ = ["settings"]
+__all__ = ["settings", "favorites_sim"]

--- a/services/favorites_sim.py
+++ b/services/favorites_sim.py
@@ -1,0 +1,422 @@
+"""Minimal persistence layer for the Favorites paper simulator.
+
+This module does not implement the full trading engine but provides
+infrastructure for storing simulator configuration and surfacing
+status/activity data through the API. It mirrors the structure used by the
+scalper paper trading services so that a future engine can plug in without
+modifying the routes layer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class FavoritesSimSettings:
+    starting_balance: float = 100000.0
+    allocation_mode: str = "percent"  # percent or fixed
+    allocation_value: float = 10.0
+    per_contract_fee: float = 0.0
+    per_order_fee: float = 0.0
+    slippage_bps: float = 0.0
+    daily_trade_cap: int = 20
+    allow_premarket: bool = False
+    allow_postmarket: bool = False
+    entry_rule: str = "next_open"
+    exit_time_cap_minutes: int = 30
+    exit_profit_target_pct: float | None = None
+    exit_max_adverse_pct: float | None = None
+
+
+@dataclass(slots=True)
+class FavoritesSimStatus:
+    status: str
+    started_at: str | None
+
+
+_RANGE_TO_DAYS = {
+    "1d": 1,
+    "1w": 7,
+    "1m": 30,
+    "3m": 90,
+}
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _now_iso() -> str:
+    return _now_utc().isoformat()
+
+
+def _ensure_tables(db) -> None:
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS paper_favorites_settings (
+            id INTEGER PRIMARY KEY CHECK (id=1),
+            starting_balance REAL NOT NULL DEFAULT 100000,
+            allocation_mode TEXT NOT NULL DEFAULT 'percent',
+            allocation_value REAL NOT NULL DEFAULT 10,
+            per_contract_fee REAL NOT NULL DEFAULT 0,
+            per_order_fee REAL NOT NULL DEFAULT 0,
+            slippage_bps REAL NOT NULL DEFAULT 0,
+            daily_trade_cap INTEGER NOT NULL DEFAULT 20,
+            allow_premarket INTEGER NOT NULL DEFAULT 0,
+            allow_postmarket INTEGER NOT NULL DEFAULT 0,
+            entry_rule TEXT NOT NULL DEFAULT 'next_open',
+            exit_time_cap_minutes INTEGER NOT NULL DEFAULT 30,
+            exit_profit_target_pct REAL,
+            exit_max_adverse_pct REAL
+        )
+        """
+    )
+    db.execute(
+        """
+        INSERT OR IGNORE INTO paper_favorites_settings(
+            id, starting_balance, allocation_mode, allocation_value,
+            per_contract_fee, per_order_fee, slippage_bps, daily_trade_cap,
+            allow_premarket, allow_postmarket, entry_rule, exit_time_cap_minutes,
+            exit_profit_target_pct, exit_max_adverse_pct
+        ) VALUES(1, 100000, 'percent', 10, 0, 0, 0, 20, 0, 0, 'next_open', 30, NULL, NULL)
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS paper_favorites_status (
+            id INTEGER PRIMARY KEY CHECK (id=1),
+            status TEXT NOT NULL DEFAULT 'inactive',
+            started_at TEXT
+        )
+        """
+    )
+    db.execute(
+        """
+        INSERT OR IGNORE INTO paper_favorites_status(id, status, started_at)
+        VALUES(1, 'inactive', NULL)
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS paper_favorites_equity (
+            ts TEXT PRIMARY KEY,
+            balance REAL NOT NULL
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS paper_favorites_activity (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            side TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            price REAL,
+            pnl REAL,
+            fees REAL,
+            metadata TEXT
+        )
+        """
+    )
+    db.connection.commit()
+
+
+def _seed_equity(db, settings: FavoritesSimSettings) -> None:
+    row = db.execute("SELECT COUNT(1) FROM paper_favorites_equity").fetchone()
+    count = int(row[0]) if row else 0
+    if count == 0:
+        db.execute(
+            "INSERT INTO paper_favorites_equity(ts, balance) VALUES(?, ?)",
+            (_now_iso(), float(settings.starting_balance)),
+        )
+        db.connection.commit()
+
+
+def load_settings(db) -> FavoritesSimSettings:
+    _ensure_tables(db)
+    row = db.execute(
+        """
+        SELECT starting_balance, allocation_mode, allocation_value, per_contract_fee,
+               per_order_fee, slippage_bps, daily_trade_cap, allow_premarket,
+               allow_postmarket, entry_rule, exit_time_cap_minutes,
+               exit_profit_target_pct, exit_max_adverse_pct
+        FROM paper_favorites_settings WHERE id=1
+        """
+    ).fetchone()
+    if not row:
+        return FavoritesSimSettings()
+    return FavoritesSimSettings(
+        starting_balance=float(row[0] or 0.0),
+        allocation_mode=str(row[1] or "percent"),
+        allocation_value=float(row[2] or 0.0),
+        per_contract_fee=float(row[3] or 0.0),
+        per_order_fee=float(row[4] or 0.0),
+        slippage_bps=float(row[5] or 0.0),
+        daily_trade_cap=int(row[6] or 0),
+        allow_premarket=bool(row[7]),
+        allow_postmarket=bool(row[8]),
+        entry_rule=str(row[9] or "next_open"),
+        exit_time_cap_minutes=int(row[10] or 0),
+        exit_profit_target_pct=float(row[11]) if row[11] is not None else None,
+        exit_max_adverse_pct=float(row[12]) if row[12] is not None else None,
+    )
+
+
+def update_settings(
+    db,
+    *,
+    starting_balance: float,
+    allocation_mode: str,
+    allocation_value: float,
+    per_contract_fee: float,
+    per_order_fee: float,
+    slippage_bps: float,
+    daily_trade_cap: int,
+    allow_premarket: bool,
+    allow_postmarket: bool,
+    entry_rule: str,
+    exit_time_cap_minutes: int,
+    exit_profit_target_pct: float | None,
+    exit_max_adverse_pct: float | None,
+) -> None:
+    _ensure_tables(db)
+    mode = allocation_mode if allocation_mode in {"percent", "fixed"} else "percent"
+    db.execute(
+        """
+        UPDATE paper_favorites_settings
+        SET starting_balance=?, allocation_mode=?, allocation_value=?,
+            per_contract_fee=?, per_order_fee=?, slippage_bps=?, daily_trade_cap=?,
+            allow_premarket=?, allow_postmarket=?, entry_rule=?, exit_time_cap_minutes=?,
+            exit_profit_target_pct=?, exit_max_adverse_pct=?
+        WHERE id=1
+        """,
+        (
+            float(max(0.0, starting_balance)),
+            mode,
+            float(max(0.0, allocation_value)),
+            float(max(0.0, per_contract_fee)),
+            float(max(0.0, per_order_fee)),
+            float(slippage_bps),
+            int(max(0, daily_trade_cap)),
+            1 if allow_premarket else 0,
+            1 if allow_postmarket else 0,
+            entry_rule if entry_rule in {"next_open", "signal_close"} else "next_open",
+            int(max(0, exit_time_cap_minutes)),
+            float(exit_profit_target_pct) if exit_profit_target_pct is not None else None,
+            float(exit_max_adverse_pct) if exit_max_adverse_pct is not None else None,
+        ),
+    )
+    db.connection.commit()
+    settings = load_settings(db)
+    _seed_equity(db, settings)
+
+
+def _status_row(db) -> FavoritesSimStatus:
+    _ensure_tables(db)
+    row = db.execute(
+        "SELECT status, started_at FROM paper_favorites_status WHERE id=1"
+    ).fetchone()
+    if not row:
+        return FavoritesSimStatus("inactive", None)
+    status = str(row[0] or "inactive")
+    started = row[1] if row[1] else None
+    return FavoritesSimStatus(status, started)
+
+
+def status_payload(db) -> dict[str, Any]:
+    status = _status_row(db)
+    return {"status": status.status, "started_at": status.started_at}
+
+
+def start(db) -> dict[str, Any]:
+    _ensure_tables(db)
+    now = _now_iso()
+    db.execute(
+        "UPDATE paper_favorites_status SET status='active', started_at=? WHERE id=1",
+        (now,),
+    )
+    db.connection.commit()
+    logger.info("favorites_sim_started", extra={"started_at": now})
+    return status_payload(db)
+
+
+def stop(db) -> dict[str, Any]:
+    _ensure_tables(db)
+    db.execute(
+        "UPDATE paper_favorites_status SET status='inactive', started_at=NULL WHERE id=1"
+    )
+    db.connection.commit()
+    logger.info("favorites_sim_stopped")
+    return status_payload(db)
+
+
+def restart(db) -> dict[str, Any]:
+    stop(db)
+    return start(db)
+
+
+def favorites_count(db) -> int:
+    try:
+        row = db.execute("SELECT COUNT(1) FROM favorites").fetchone()
+    except Exception:
+        logger.exception("favorites_count_failed")
+        return 0
+    if not row:
+        return 0
+    return int(row[0] or 0)
+
+
+def _parse_iso(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _equity_rows(db) -> list[tuple[str, float]]:
+    _ensure_tables(db)
+    rows = db.execute(
+        "SELECT ts, balance FROM paper_favorites_equity ORDER BY ts ASC"
+    ).fetchall()
+    settings = load_settings(db)
+    if not rows:
+        _seed_equity(db, settings)
+        rows = db.execute(
+            "SELECT ts, balance FROM paper_favorites_equity ORDER BY ts ASC"
+        ).fetchall()
+    return [(str(ts), float(balance)) for ts, balance in rows]
+
+
+def get_equity_points(db, range_key: str) -> list[dict[str, Any]]:
+    rows = _equity_rows(db)
+    if not rows:
+        return []
+    if range_key and range_key != "all":
+        days = _RANGE_TO_DAYS.get(range_key)
+        if days:
+            cutoff = _now_utc() - timedelta(days=days)
+            filtered: list[tuple[str, float]] = []
+            for ts, balance in rows:
+                parsed = _parse_iso(ts)
+                if parsed is None or parsed >= cutoff:
+                    filtered.append((ts, balance))
+            if filtered:
+                rows = filtered
+    return [{"ts": ts, "balance": bal} for ts, bal in rows]
+
+
+def _current_balance(rows: Iterable[tuple[str, float]]) -> float:
+    last = None
+    for last in rows:
+        pass
+    if last is None:
+        return 0.0
+    return float(last[1])
+
+
+def summary_payload(db) -> dict[str, Any]:
+    settings = load_settings(db)
+    rows = _equity_rows(db)
+    balance = _current_balance(rows)
+    status = _status_row(db)
+    pnl = balance - settings.starting_balance
+    pnl_pct = 0.0
+    if settings.starting_balance:
+        pnl_pct = (pnl / settings.starting_balance) * 100.0
+    wins = 0
+    losses = 0
+    total_trades = 0
+    avg_win = 0.0
+    avg_loss = 0.0
+    max_drawdown = 0.0
+    try:
+        trades = list_activity(db)
+    except Exception:
+        trades = []
+    for trade in trades:
+        roi = trade.get("roi_pct")
+        if roi is None:
+            continue
+        total_trades += 1
+        if roi > 0:
+            wins += 1
+        elif roi < 0:
+            losses += 1
+    if wins:
+        win_pnls = [t.get("pnl") for t in trades if (t.get("roi_pct") or 0) > 0]
+        win_pnls = [float(v) for v in win_pnls if v is not None]
+        if win_pnls:
+            avg_win = sum(win_pnls) / len(win_pnls)
+    if losses:
+        loss_pnls = [t.get("pnl") for t in trades if (t.get("roi_pct") or 0) < 0]
+        loss_pnls = [float(v) for v in loss_pnls if v is not None]
+        if loss_pnls:
+            avg_loss = sum(loss_pnls) / len(loss_pnls)
+    win_rate = (wins / total_trades * 100.0) if total_trades else 0.0
+    universe = favorites_count(db)
+    return {
+        "status": status.status,
+        "started_at": status.started_at,
+        "balance": balance,
+        "starting_balance": settings.starting_balance,
+        "pnl": pnl,
+        "pnl_pct": pnl_pct,
+        "win_rate": win_rate,
+        "avg_win": avg_win,
+        "avg_loss": avg_loss,
+        "max_drawdown": max_drawdown,
+        "total_trades": total_trades,
+        "universe": universe,
+    }
+
+
+def list_activity(db, limit: int | None = None) -> list[dict[str, Any]]:
+    _ensure_tables(db)
+    query = "SELECT ts, symbol, side, quantity, price, pnl, fees, metadata FROM paper_favorites_activity ORDER BY ts DESC"
+    if limit:
+        query += f" LIMIT {int(limit)}"
+    rows = db.execute(query).fetchall()
+    payload: list[dict[str, Any]] = []
+    for ts, symbol, side, quantity, price, pnl, fees, metadata in rows:
+        meta: dict[str, Any] = {}
+        if metadata:
+            try:
+                meta = json.loads(metadata)
+            except (TypeError, json.JSONDecodeError):
+                meta = {"raw": metadata}
+        payload.append(
+            {
+                "ts": ts,
+                "symbol": symbol,
+                "side": side,
+                "quantity": quantity,
+                "price": price,
+                "pnl": pnl,
+                "fees": fees,
+                "metadata": meta,
+                "entry_time": meta.get("entry_time") if isinstance(meta, dict) else None,
+                "exit_time": meta.get("exit_time") if isinstance(meta, dict) else None,
+                "entry_price": meta.get("entry_price") if isinstance(meta, dict) else None,
+                "exit_price": meta.get("exit_price") if isinstance(meta, dict) else None,
+                "roi_pct": meta.get("roi_pct") if isinstance(meta, dict) else None,
+                "status": meta.get("status") if isinstance(meta, dict) else None,
+            }
+        )
+    return payload
+
+
+def activity_payload(db) -> dict[str, Any]:
+    return {"rows": list_activity(db)}

--- a/static/js/paper_favorites.js
+++ b/static/js/paper_favorites.js
@@ -1,0 +1,359 @@
+(function () {
+  const statusSeed = safeParseJson('favorites-status-seed');
+  const summarySeed = safeParseJson('favorites-summary-seed');
+  const equitySeed = safeParseJson('favorites-equity-seed');
+  const activitySeed = safeParseJson('favorites-activity-seed');
+
+  const sectionEl = document.querySelector('section[data-has-universe]');
+  const hasUniverse = (sectionEl?.dataset.hasUniverse || 'false') === 'true';
+  const metricsEl = document.getElementById('favorites-metrics');
+  const pillEl = document.getElementById('favorites-status-pill');
+  const statusLineEl = document.getElementById('favorites-status-line');
+  const rangeButtons = Array.from(document.querySelectorAll('[data-range]'));
+  const actionButtons = Array.from(document.querySelectorAll('[data-favorites-action]'));
+  actionButtons.forEach((btn) => {
+    btn.dataset.disabledInitial = btn.disabled ? '1' : '0';
+  });
+  const chartCanvas = document.getElementById('favorites-equity-chart');
+  const activityBody = document.getElementById('favorites-activity-body');
+  const toast = document.getElementById('toast');
+
+  const currencyFmt = new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' });
+  const percentFmt = new Intl.NumberFormat(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  const shortPercentFmt = new Intl.NumberFormat(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+  const dateTimeFmt = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+
+  let currentRange = '1m';
+  let chartPoints = Array.isArray(equitySeed) ? equitySeed : [];
+
+  function safeParseJson(id) {
+    const el = document.getElementById(id);
+    if (!el) return null;
+    try {
+      return JSON.parse(el.textContent || 'null');
+    } catch (err) {
+      return null;
+    }
+  }
+
+  function showToast(message, ok = true) {
+    if (!toast) return;
+    toast.textContent = message;
+    toast.style.borderColor = ok ? '#2e7d32' : '#8b0000';
+    toast.style.background = ok ? '#0f3311' : '#2b0f0f';
+    toast.hidden = false;
+    setTimeout(() => {
+      toast.hidden = true;
+    }, 2400);
+  }
+
+  function formatCurrency(value) {
+    return currencyFmt.format(Number(value) || 0);
+  }
+
+  function formatPercent(value) {
+    return `${percentFmt.format(Number(value) || 0)}%`;
+  }
+
+  function formatShortPercent(value) {
+    return `${shortPercentFmt.format(Number(value) || 0)}%`;
+  }
+
+  function updateMetrics(summary, universeCount) {
+    if (!metricsEl) return;
+    const data = summary || {};
+    const map = {
+      equity: formatCurrency(data.balance),
+      pnl: formatCurrency(data.pnl),
+      pnl_pct: formatPercent(data.pnl_pct),
+      win_rate: formatShortPercent(data.win_rate),
+      trades: Number(data.total_trades || 0).toString(),
+      avg_win: formatCurrency(data.avg_win),
+      avg_loss: formatCurrency(data.avg_loss),
+      max_drawdown: formatPercent(data.max_drawdown),
+      universe: Number(universeCount || data.universe || 0).toString(),
+    };
+    Object.entries(map).forEach(([key, value]) => {
+      const el = metricsEl.querySelector(`[data-metric="${key}"]`);
+      if (el) {
+        el.textContent = value;
+      }
+    });
+  }
+
+  function updateStatus(status) {
+    if (!statusLineEl) return;
+    if (!hasUniverse) {
+      statusLineEl.textContent = 'No favorites available. Add favorites from the scanner to begin simulating.';
+      if (pillEl) {
+        pillEl.classList.remove('active');
+        pillEl.textContent = 'Inactive';
+      }
+      return;
+    }
+    const state = (status.status || '').toLowerCase();
+    const startedRaw = status.started_at;
+    let startedLabel = startedRaw;
+    if (startedRaw) {
+      const parsed = new Date(startedRaw);
+      if (!Number.isNaN(parsed.valueOf())) {
+        startedLabel = dateTimeFmt.format(parsed);
+      }
+    }
+    if (state === 'active' && startedLabel) {
+      statusLineEl.textContent = `Active since ${startedLabel}`;
+    } else if (state === 'active') {
+      statusLineEl.textContent = 'Active and monitoring favorites hits.';
+    } else {
+      statusLineEl.textContent = 'Simulator is currently inactive.';
+    }
+    if (pillEl) {
+      pillEl.classList.toggle('active', state === 'active');
+      pillEl.textContent = state === 'active' ? 'Active' : 'Inactive';
+    }
+  }
+
+  function setActionsDisabled(disabled) {
+    actionButtons.forEach((btn) => {
+      if (disabled) {
+        btn.disabled = true;
+      } else {
+        btn.disabled = btn.dataset.disabledInitial === '1';
+      }
+    });
+  }
+
+  function renderActivity(rows) {
+    if (!activityBody) return;
+    const items = Array.isArray(rows) ? rows : [];
+    if (!items.length) {
+      activityBody.innerHTML = '<tr><td colspan="8" class="muted">No simulated trades yet.</td></tr>';
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    items.forEach((row) => {
+      const tr = document.createElement('tr');
+      const ts = row.entry_time || row.ts;
+      const exitTime = row.exit_time;
+      const pnl = Number(row.pnl);
+      const roi = Number(row.roi_pct);
+      const qty = Number(row.quantity || row.qty || 0);
+      const entryPrice = row.entry_price != null ? formatCurrency(row.entry_price) : '—';
+      const exitPrice = row.exit_price != null ? formatCurrency(row.exit_price) : '—';
+      const timeCell = document.createElement('td');
+      if (ts) {
+        const parsed = new Date(ts);
+        timeCell.textContent = Number.isNaN(parsed.valueOf()) ? ts : dateTimeFmt.format(parsed);
+        timeCell.title = ts;
+      } else {
+        timeCell.textContent = '—';
+      }
+      const exitCell = document.createElement('td');
+      if (exitTime) {
+        const parsedExit = new Date(exitTime);
+        exitCell.textContent = Number.isNaN(parsedExit.valueOf()) ? exitTime : dateTimeFmt.format(parsedExit);
+        exitCell.title = exitTime;
+      } else {
+        exitCell.textContent = '—';
+      }
+      const cells = [
+        timeCell,
+        row.symbol || '—',
+        row.side ? String(row.side).toUpperCase() : '—',
+        qty.toString(),
+        entryPrice,
+        exitPrice,
+        formatCurrency(pnl || 0),
+        Number.isFinite(roi) ? `${percentFmt.format(roi)}%` : '—',
+      ];
+      cells.forEach((cell) => {
+        let td;
+        if (cell instanceof HTMLElement) {
+          td = cell;
+        } else {
+          td = document.createElement('td');
+          td.textContent = cell;
+        }
+        tr.appendChild(td);
+      });
+      fragment.appendChild(tr);
+    });
+    activityBody.innerHTML = '';
+    activityBody.appendChild(fragment);
+  }
+
+  function renderChart(points) {
+    if (!chartCanvas) return;
+    const ctx = chartCanvas.getContext('2d');
+    if (!ctx) return;
+    const dataset = Array.isArray(points) ? points : [];
+    const dpr = window.devicePixelRatio || 1;
+    const rect = chartCanvas.getBoundingClientRect();
+    const width = rect.width || 640;
+    const height = rect.height || 260;
+    chartCanvas.width = width * dpr;
+    chartCanvas.height = height * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, width, height);
+    if (!dataset.length) {
+      return;
+    }
+    const parsed = dataset
+      .map((pt) => ({
+        ts: pt.ts,
+        date: new Date(pt.ts),
+        balance: Number(pt.balance) || 0,
+      }))
+      .filter((pt) => !Number.isNaN(pt.date.valueOf()));
+    if (!parsed.length) {
+      return;
+    }
+    const minBal = Math.min(...parsed.map((pt) => pt.balance));
+    const maxBal = Math.max(...parsed.map((pt) => pt.balance));
+    const minTime = Math.min(...parsed.map((pt) => pt.date.valueOf()));
+    const maxTime = Math.max(...parsed.map((pt) => pt.date.valueOf()));
+    const padX = 24;
+    const padY = 18;
+    const chartW = width - padX * 2;
+    const chartH = height - padY * 2;
+    const spanBal = Math.max(1e-3, maxBal - minBal);
+    const spanTime = Math.max(1e-3, maxTime - minTime);
+    const path = parsed.map((pt) => {
+      const x = padX + ((pt.date.valueOf() - minTime) / spanTime) * chartW;
+      const y = padY + (1 - (pt.balance - minBal) / spanBal) * chartH;
+      return { x, y, balance: pt.balance, ts: pt.ts };
+    });
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = 'rgba(94,160,255,0.85)';
+    ctx.beginPath();
+    path.forEach((pt, idx) => {
+      if (idx === 0) {
+        ctx.moveTo(pt.x, pt.y);
+      } else {
+        ctx.lineTo(pt.x, pt.y);
+      }
+    });
+    ctx.stroke();
+    ctx.fillStyle = 'rgba(94,160,255,0.15)';
+    ctx.lineTo(path[path.length - 1].x, height - padY);
+    ctx.lineTo(path[0].x, height - padY);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  function fetchStatus() {
+    return fetch('/api/paper/favorites/status', { credentials: 'same-origin' })
+      .then((resp) => {
+        if (!resp.ok) throw new Error('status_failed');
+        return resp.json();
+      })
+      .then((payload) => {
+        updateMetrics(payload, payload.favorites_universe_count);
+        updateStatus(payload);
+        return payload;
+      })
+      .catch((err) => {
+        console.error('favorites_status_error', err);
+        showToast('Unable to load simulator status.', false);
+        return null;
+      });
+  }
+
+  function fetchEquity(rangeKey) {
+    const key = rangeKey || currentRange || '1m';
+    return fetch(`/api/paper/favorites/equity.json?range=${encodeURIComponent(key)}`, {
+      credentials: 'same-origin',
+    })
+      .then((resp) => {
+        if (!resp.ok) throw new Error('equity_failed');
+        return resp.json();
+      })
+      .then((payload) => {
+        chartPoints = payload.points || [];
+        renderChart(chartPoints);
+        return payload;
+      })
+      .catch((err) => {
+        console.error('favorites_equity_error', err);
+        showToast('Unable to load equity curve.', false);
+        return null;
+      });
+  }
+
+  function fetchActivity() {
+    return fetch('/api/paper/favorites/activity', { credentials: 'same-origin' })
+      .then((resp) => {
+        if (!resp.ok) throw new Error('activity_failed');
+        return resp.json();
+      })
+      .then((payload) => {
+        renderActivity(payload.rows || []);
+        return payload;
+      })
+      .catch((err) => {
+        console.error('favorites_activity_error', err);
+        showToast('Unable to load simulator activity.', false);
+        return null;
+      });
+  }
+
+  function requestAction(action) {
+    if (!action) return;
+    setActionsDisabled(true);
+    fetch(`/api/paper/favorites/${action}`, {
+      method: 'POST',
+      credentials: 'same-origin',
+    })
+      .then((resp) => {
+        if (!resp.ok) throw new Error('action_failed');
+        return resp.json();
+      })
+      .then((payload) => {
+        updateMetrics(payload, payload.favorites_universe_count);
+        updateStatus(payload);
+        const verb = action === 'start' ? 'started' : action === 'stop' ? 'stopped' : 'restarted';
+        showToast(`Favorites simulator ${verb}.`, true);
+      })
+      .catch((err) => {
+        console.error('favorites_action_error', err);
+        showToast('Unable to update simulator state.', false);
+      })
+      .finally(() => {
+        setActionsDisabled(false);
+        fetchEquity(currentRange);
+        fetchActivity();
+      });
+  }
+
+  rangeButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const range = btn.dataset.range;
+      if (!range) return;
+      rangeButtons.forEach((other) => other.classList.remove('is-active'));
+      btn.classList.add('is-active');
+      currentRange = range;
+      fetchEquity(range);
+    });
+  });
+
+  actionButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const action = btn.dataset.favoritesAction;
+      requestAction(action);
+    });
+  });
+
+  if (summarySeed) {
+    updateMetrics(summarySeed, summarySeed.universe || 0);
+  }
+  if (statusSeed) {
+    updateStatus(statusSeed);
+  }
+  renderChart(chartPoints);
+  if (activitySeed && typeof activitySeed === 'object') {
+    renderActivity(activitySeed.rows || []);
+  }
+
+  fetchStatus();
+  fetchActivity();
+})();

--- a/templates/paper.html
+++ b/templates/paper.html
@@ -10,7 +10,7 @@
       <p id="paper-status-line"></p>
     </div>
     <nav class="paper-subtabs" aria-label="Paper trading modes">
-      <a class="paper-subtab" href="/favorites">Favorites</a>
+      <a class="paper-subtab" href="/paper/favorites">Favorites (Sim)</a>
       <a class="paper-subtab is-active" href="#lf-section">Low Frequency</a>
       <a class="paper-subtab" href="#hf-section">High Frequency</a>
     </nav>

--- a/templates/paper_favorites.html
+++ b/templates/paper_favorites.html
@@ -1,0 +1,143 @@
+{% extends 'base.html' %}
+{% block title %}Paper ▸ Favorites (Sim) — Petra Stock{% endblock %}
+{% block head_extra %}
+  <script src="{{ url_for('static', path='js/paper_favorites.js') }}" defer></script>
+{% endblock %}
+{% block content %}
+  {% set has_universe = favorites_universe_count and favorites_universe_count > 0 %}
+  <div class="paper-container favorites-sim">
+    <nav class="paper-subtabs" aria-label="Paper trading modes">
+      <a class="paper-subtab is-active" href="/paper/favorites">Favorites (Sim)</a>
+      <a class="paper-subtab" href="/paper#lf-section">Scalper (LF)</a>
+      <a class="paper-subtab" href="/paper#hf-section">Scalper (HF)</a>
+    </nav>
+
+    <section class="paper-section" aria-labelledby="favorites-sim-heading" data-has-universe="{{ 'true' if has_universe else 'false' }}">
+      <div class="card paper-header-card">
+        <header class="paper-lf-header">
+          <div class="paper-metrics" id="favorites-metrics" data-status="{{ favorites_status['status'] }}" data-started="{{ favorites_status['started_at'] or '' }}">
+            <h2 id="favorites-sim-heading" class="visually-hidden">Favorites Simulator</h2>
+            <div class="paper-metric">
+              <p class="paper-label">Account Equity</p>
+              <strong data-metric="equity">${{ '%.2f'|format(favorites_summary['balance']) }}</strong>
+            </div>
+            <div class="paper-metric">
+              <p class="paper-label">P&amp;L</p>
+              <strong data-metric="pnl">${{ '%.2f'|format(favorites_summary['pnl']) }}</strong>
+            </div>
+            <div class="paper-metric">
+              <p class="paper-label">P&amp;L %</p>
+              <strong data-metric="pnl_pct">{{ '%.2f'|format(favorites_summary['pnl_pct']) }}%</strong>
+            </div>
+            <div class="paper-metric">
+              <p class="paper-label">Win Rate</p>
+              <strong data-metric="win_rate">{{ '%.1f'|format(favorites_summary['win_rate']) }}%</strong>
+            </div>
+            <div class="paper-metric">
+              <p class="paper-label">Trades</p>
+              <strong data-metric="trades">{{ favorites_summary['total_trades'] }}</strong>
+            </div>
+          </div>
+          <div class="paper-range-toggle" role="group" aria-label="Favorites equity range">
+            {% set default_range = '1m' %}
+            {% for key,label in {'1d':'1D','1w':'1W','1m':'1M','3m':'3M','all':'All'}.items() %}
+              <button type="button" class="paper-range-btn {% if key == default_range %}is-active{% endif %}" data-range="{{ key }}">{{ label }}</button>
+            {% endfor %}
+          </div>
+        </header>
+        <div class="favorites-status-bar">
+          <span id="favorites-status-pill" class="paper-status-pill {% if favorites_status['status'] == 'active' %}active{% endif %}">
+            {% if favorites_status['status'] == 'active' %}Active{% else %}Inactive{% endif %}
+          </span>
+          <div class="paper-settings-actions">
+            <button type="button" class="btn btn-secondary" data-favorites-action="start" {% if not has_universe %}disabled{% endif %}>Start</button>
+            <button type="button" class="btn btn-secondary" data-favorites-action="stop" {% if not has_universe %}disabled{% endif %}>Stop</button>
+            <button type="button" class="btn btn-secondary" data-favorites-action="restart" {% if not has_universe %}disabled{% endif %}>Restart</button>
+          </div>
+        </div>
+        <p id="favorites-status-line" class="paper-status-line">
+          {% if has_universe %}
+            {% if favorites_status['status'] == 'active' and favorites_status['started_at'] %}
+              Active since {{ favorites_status['started_at'] }}
+            {% elif favorites_status['status'] == 'active' %}
+              Active and monitoring favorites hits.
+            {% else %}
+              Simulator is currently inactive.
+            {% endif %}
+          {% else %}
+            No favorites available. Add favorites from the scanner to begin simulating.
+          {% endif %}
+        </p>
+        <div class="paper-chart-wrapper">
+          <canvas id="favorites-equity-chart" height="260" aria-label="Favorites simulator equity chart"></canvas>
+        </div>
+        <div class="paper-secondary-metrics" id="favorites-secondary-metrics">
+          <div class="paper-metric">
+            <p class="paper-label">Avg Win</p>
+            <strong data-metric="avg_win">${{ '%.2f'|format(favorites_summary['avg_win']) }}</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Avg Loss</p>
+            <strong data-metric="avg_loss">${{ '%.2f'|format(favorites_summary['avg_loss']) }}</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Max Drawdown</p>
+            <strong data-metric="max_drawdown">{{ '%.2f'|format(favorites_summary['max_drawdown']) }}%</strong>
+          </div>
+          <div class="paper-metric">
+            <p class="paper-label">Universe</p>
+            <strong data-metric="universe">{{ favorites_universe_count }}</strong>
+          </div>
+        </div>
+      </div>
+
+      <div class="card paper-table-card">
+        <div class="paper-table-toolbar">
+          <h3 class="paper-table-title">Recent Favorites Activity</h3>
+        </div>
+        <div class="paper-table-scroll">
+          <table id="favorites-activity-table" class="table paper-table" aria-describedby="favorites-status-line">
+            <thead>
+              <tr>
+                <th scope="col">Time</th>
+                <th scope="col">Symbol</th>
+                <th scope="col">Side</th>
+                <th scope="col">Qty</th>
+                <th scope="col">Entry</th>
+                <th scope="col">Exit</th>
+                <th scope="col">P&amp;L</th>
+                <th scope="col">ROI%</th>
+              </tr>
+            </thead>
+            <tbody id="favorites-activity-body"></tbody>
+          </table>
+        </div>
+      </div>
+
+      {% if not has_universe %}
+      <div class="card" id="favorites-empty-state">
+        <p>No favorites yet. Add symbols to your Favorites list to enable the simulator.</p>
+      </div>
+      {% endif %}
+    </section>
+  </div>
+  <script type="application/json" id="favorites-status-seed">{{ favorites_status|tojson|safe }}</script>
+  <script type="application/json" id="favorites-summary-seed">{{ favorites_summary|tojson|safe }}</script>
+  <script type="application/json" id="favorites-equity-seed">{{ favorites_equity|tojson|safe }}</script>
+  <script type="application/json" id="favorites-activity-seed">{{ favorites_activity|tojson|safe }}</script>
+  <script type="application/json" id="favorites-settings-seed">{{ {
+    'starting_balance': favorites_settings.starting_balance,
+    'allocation_mode': favorites_settings.allocation_mode,
+    'allocation_value': favorites_settings.allocation_value,
+    'per_contract_fee': favorites_settings.per_contract_fee,
+    'per_order_fee': favorites_settings.per_order_fee,
+    'slippage_bps': favorites_settings.slippage_bps,
+    'daily_trade_cap': favorites_settings.daily_trade_cap,
+    'allow_premarket': favorites_settings.allow_premarket,
+    'allow_postmarket': favorites_settings.allow_postmarket,
+    'entry_rule': favorites_settings.entry_rule,
+    'exit_time_cap_minutes': favorites_settings.exit_time_cap_minutes,
+    'exit_profit_target_pct': favorites_settings.exit_profit_target_pct,
+    'exit_max_adverse_pct': favorites_settings.exit_max_adverse_pct
+  }|tojson|safe }}</script>
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -216,6 +216,90 @@
       <p class="note status-error" style="margin-top:.5rem;">SMTP configuration incomplete: {{ smtp_missing_label }}</p>
       {% endif %}
 
+      <div class="paper-settings-card" id="favorites-settings-card" data-status="{{ favorites_sim_status['status'] }}" data-started="{{ favorites_sim_status['started_at'] or '' }}" data-universe="{{ favorites_universe_count }}">
+        <div class="paper-settings-header">
+          <h2 style="margin:0;">Paper ▸ Favorites (Sim)</h2>
+          <span id="favorites-settings-pill" class="paper-status-pill {% if favorites_sim_status['status'] == 'active' %}active{% endif %}">
+            {% if favorites_sim_status['status'] == 'active' %}Active{% else %}Inactive{% endif %}
+          </span>
+        </div>
+        <p class="note" style="margin:0;">Simulates trades using your Favorites hit stream. Universe currently <strong>{{ favorites_universe_count }}</strong> symbols.</p>
+        <div class="lf-settings-grid">
+          <label>Starting balance
+            <input name="favorites_starting_balance" type="number" step="0.01" min="0" value="{{ '%.2f'|format(favorites_sim_settings.starting_balance) }}" />
+          </label>
+          <label>Allocation mode
+            <select name="favorites_allocation_mode">
+              {% set fav_mode = favorites_sim_settings.allocation_mode %}
+              <option value="percent" {% if fav_mode == 'percent' %}selected{% endif %}>% of equity</option>
+              <option value="fixed" {% if fav_mode == 'fixed' %}selected{% endif %}>Fixed $</option>
+            </select>
+          </label>
+          <label>Allocation value
+            <input name="favorites_allocation_value" type="number" step="0.01" min="0" value="{{ '%.2f'|format(favorites_sim_settings.allocation_value) }}" />
+          </label>
+          <label>Daily trade cap
+            <input name="favorites_daily_cap" type="number" min="0" value="{{ favorites_sim_settings.daily_trade_cap }}" />
+          </label>
+        </div>
+        <div class="lf-settings-grid">
+          <label>Per-contract fee
+            <input name="favorites_per_contract_fee" type="number" step="0.01" min="0" value="{{ '%.2f'|format(favorites_sim_settings.per_contract_fee) }}" />
+          </label>
+          <label>Per-order fee
+            <input name="favorites_per_order_fee" type="number" step="0.01" min="0" value="{{ '%.2f'|format(favorites_sim_settings.per_order_fee) }}" />
+          </label>
+          <label>Slippage (bps)
+            <input name="favorites_slippage_bps" type="number" step="0.1" value="{{ '%.1f'|format(favorites_sim_settings.slippage_bps) }}" />
+          </label>
+          <label>Entry price rule
+            {% set fav_entry = favorites_sim_settings.entry_rule %}
+            <select name="favorites_entry_rule">
+              <option value="next_open" {% if fav_entry == 'next_open' %}selected{% endif %}>Next bar open</option>
+              <option value="signal_close" {% if fav_entry == 'signal_close' %}selected{% endif %}>Signal bar close</option>
+            </select>
+          </label>
+        </div>
+        <div class="lf-settings-grid">
+          <label>Time cap (minutes)
+            <input name="favorites_exit_time_cap" type="number" min="0" value="{{ favorites_sim_settings.exit_time_cap_minutes }}" />
+          </label>
+          <label>Profit target % (optional)
+            <input name="favorites_exit_profit_target" type="number" step="0.1" value="{{ '' if favorites_sim_settings.exit_profit_target_pct is none else '%.1f'|format(favorites_sim_settings.exit_profit_target_pct) }}" />
+          </label>
+          <label>Max adverse % (optional)
+            <input name="favorites_exit_max_adverse" type="number" step="0.1" value="{{ '' if favorites_sim_settings.exit_max_adverse_pct is none else '%.1f'|format(favorites_sim_settings.exit_max_adverse_pct) }}" />
+          </label>
+        </div>
+        <div class="lf-settings-grid">
+          <label class="checkbox" style="align-items:center;">
+            <input type="checkbox" name="favorites_allow_premarket" value="1" {% if favorites_sim_settings.allow_premarket %}checked{% endif %} />
+            <span>Allow pre-market</span>
+          </label>
+          <label class="checkbox" style="align-items:center;">
+            <input type="checkbox" name="favorites_allow_postmarket" value="1" {% if favorites_sim_settings.allow_postmarket %}checked{% endif %} />
+            <span>Allow post-market</span>
+          </label>
+        </div>
+        <div class="paper-settings-actions">
+          <button type="button" class="btn btn-secondary" data-favorites-sim-action="start" {% if favorites_universe_count == 0 %}disabled{% endif %}>Start</button>
+          <button type="button" class="btn btn-secondary" data-favorites-sim-action="stop" {% if favorites_universe_count == 0 %}disabled{% endif %}>Stop</button>
+          <button type="button" class="btn btn-secondary" data-favorites-sim-action="restart" {% if favorites_universe_count == 0 %}disabled{% endif %}>Restart</button>
+        </div>
+        <p id="favorites-settings-status" class="note" style="margin-top:0.5rem;">
+          {% if favorites_universe_count == 0 %}
+            Add favorites from the scanner to enable the simulator.
+          {% elif favorites_sim_status['status'] == 'active' and favorites_sim_status['started_at'] %}
+            Active since {{ favorites_sim_status['started_at'] }}
+          {% elif favorites_sim_status['status'] == 'active' %}
+            Active and monitoring favorites hits.
+          {% else %}
+            Simulator is currently inactive.
+          {% endif %}
+        </p>
+      </div>
+      <script type="application/json" id="favorites-settings-status-seed">{{ favorites_sim_status|tojson|safe }}</script>
+
       <div class="paper-settings-card" id="lf-settings-card" data-status="{{ scalper_status.status }}" data-started="{{ scalper_status.started_at or '' }}">
         <div class="paper-settings-header">
           <h2 style="margin:0;">Paper ▸ Scalper (Low Frequency)</h2>
@@ -576,6 +660,104 @@
     });
 
     renderLfStatus(lfSeed);
+
+    const favSettingsCard = document.getElementById('favorites-settings-card');
+    const favSettingsStatusEl = document.getElementById('favorites-settings-status');
+    const favSettingsPill = document.getElementById('favorites-settings-pill');
+    const favButtons = Array.from(document.querySelectorAll('[data-favorites-sim-action]'));
+    favButtons.forEach((btn) => {
+      btn.dataset.disabledInitial = btn.disabled ? '1' : '0';
+    });
+    const favHasUniverse = Number(favSettingsCard?.dataset.universe || '0') > 0;
+    const favSeedEl = document.getElementById('favorites-settings-status-seed');
+    let favSeed = {};
+    try {
+      favSeed = JSON.parse(favSeedEl?.textContent || '{}') || {};
+    } catch (err) {
+      favSeed = {};
+    }
+
+    function renderFavStatus(data) {
+      if (!data) return;
+      if (!favHasUniverse) {
+        if (favSettingsStatusEl) {
+          favSettingsStatusEl.textContent = 'Add favorites from the scanner to enable the simulator.';
+        }
+        return;
+      }
+      const status = (data.status || '').toLowerCase();
+      const startedRaw = data.started_at || '';
+      let startedLabel = startedRaw;
+      if (startedRaw) {
+        const parsed = new Date(startedRaw);
+        if (!Number.isNaN(parsed.valueOf())) {
+          startedLabel = lfDateFmt.format(parsed);
+        }
+      }
+      if (favSettingsStatusEl) {
+        if (status === 'active' && startedLabel) {
+          favSettingsStatusEl.textContent = `Active since ${startedLabel}`;
+        } else if (status === 'active') {
+          favSettingsStatusEl.textContent = 'Active and monitoring favorites hits.';
+        } else {
+          favSettingsStatusEl.textContent = 'Simulator is currently inactive.';
+        }
+      }
+      if (favSettingsPill) {
+        if (status === 'active') {
+          favSettingsPill.classList.add('active');
+          favSettingsPill.textContent = 'Active';
+        } else {
+          favSettingsPill.classList.remove('active');
+          favSettingsPill.textContent = 'Inactive';
+        }
+      }
+    }
+
+    function setFavButtonsDisabled(disabled) {
+      favButtons.forEach((btn) => {
+        if (disabled) {
+          btn.disabled = true;
+        } else {
+          btn.disabled = btn.dataset.disabledInitial === '1';
+        }
+      });
+    }
+
+    function requestFavAction(action) {
+      if (!action) return;
+      setFavButtonsDisabled(true);
+      fetch(`/api/paper/favorites/${action}`, {
+        method: 'POST',
+        credentials: 'same-origin',
+      })
+        .then((resp) => {
+          if (!resp.ok) throw new Error('request_failed');
+          return resp.json();
+        })
+        .then((payload) => {
+          renderFavStatus(payload);
+          const verb = action === 'start'
+            ? 'started'
+            : action === 'stop'
+              ? 'stopped'
+              : 'restarted';
+          showToast(`Favorites simulator ${verb}.`, true);
+        })
+        .catch(() => {
+          showToast('Unable to update favorites simulator.', false);
+        })
+        .finally(() => setFavButtonsDisabled(false));
+    }
+
+    favButtons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const action = btn.dataset.favoritesSimAction;
+        requestFavAction(action);
+      });
+    });
+
+    renderFavStatus(favSeed);
 
     const hfStatusEl = document.getElementById('hf-settings-status');
     const hfPill = document.getElementById('hf-status-pill');


### PR DESCRIPTION
## Summary
- add a service layer module and routes for the favorites paper simulator, including equity, activity, and status endpoints
- create a dedicated Favorites (Sim) paper trading page with chart, metrics, and controls
- expand settings to configure favorites simulator allocation, fees, entry/exit rules, and session toggles

## Testing
- pytest *(fails: tests/test_data_provider.py::test_fetch_bars_uses_schwab, tests/test_data_provider.py::test_fetch_bars_fallbacks_to_yfinance)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e3704af88329b7dd664ee00ac2aa