### PR TITLE
Refactor scanner data fetch to stay async

### DIFF
--- a/services/http_client.py
+++ b/services/http_client.py
@@ -330,9 +330,10 @@ async def request(method: str, url: str, **kwargs) -> httpx.Response:
         try:
             return await task
         finally:
-            loop_inflight.pop(key, None)
-            if not loop_inflight:
-                _INFLIGHT.pop(loop_id, None)
+            if task.done():
+                loop_inflight.pop(key, None)
+                if not loop_inflight:
+                    _INFLIGHT.pop(loop_id, None)
     else:
         return await _do_request()
 


### PR DESCRIPTION
## Summary
- build a reusable scan plan so coverage work can be shared between the request handler and the scan executor
- run the scanner fetch stage on the current loop, awaiting `fetch_bars_async` with heartbeat logging before dispatching the compute phase
- update the data provider to gather symbol fetches under a semaphore and expose fetch statistics, and tighten HTTP inflight task cleanup

## Testing
- pytest tests/test_scan_fetch_concurrency.py

------
https://chatgpt.com/codex/tasks/task_e_68e1eb02aa548329b493751a33338a7b