### PR TITLE
Clarify SMS consent copy and contact info

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -64,7 +64,7 @@ from services.favorites import canonical_direction, ensure_favorite_directions
 from services.notify import send_email_smtp
 from services.scanner_params import coerce_scan_params
 from services.telemetry import log as log_telemetry
-from services.config import DEBUG_SIMULATION
+from services.config import DEBUG_SIMULATION, SMS_MAX_PER_MONTH
 from services.favorites_alerts import deliver_preview_alert
 from services.simulator import SimEvent, build_sim_hit, build_sim_stop
 from services.scheduler import _align_to_bar, _dedupe_key, was_sent_key
@@ -171,10 +171,11 @@ def _build_scan_plan(tickers: list[str], params: dict) -> ScanPlan:
     )
 
 _SMS_CONSENT_TEXT = (
-    "I agree to receive automated Petra Stock SMS alerts. Msg & data rates may apply. "
-    "Message frequency varies by market activity and your settings, typically up to 10 msgs/day. "
-    "Alerts are informational only and not financial advice. By checking this box, I agree to the "
-    "Terms and Privacy Policy."
+    "I agree to receive automated Petra Stock SMS alerts about pattern signals and "
+    "performance updates. "
+    f"No more than {SMS_MAX_PER_MONTH} texts/month. Msg & data rates may apply. "
+    "Text STOP to opt out, HELP for help. "
+    "By checking this box, I agree to the Terms and Privacy Policy."
 )
 
 

--- a/routes/template_helpers.py
+++ b/routes/template_helpers.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import math
+import re
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Dict
 
 import pandas as pd
 from fastapi.templating import Jinja2Templates
+
+from services import config as services_config
 
 
 def fmt_percent(value: Any, decimals: int = 2) -> str:
@@ -81,4 +84,37 @@ def register_template_helpers(templates: Jinja2Templates) -> None:
     templates.env.globals["current_year"] = (
         lambda: datetime.now(timezone.utc).year
     )
+    templates.env.globals["sms_frequency_copy"] = sms_frequency_copy
+    templates.env.globals["business_contact"] = business_contact
+
+
+def sms_frequency_copy() -> str:
+    limit = max(1, int(getattr(services_config, "SMS_MAX_PER_MONTH", 50)))
+    return f"No more than {limit} texts/month. Msg & data rates may apply."
+
+
+def business_contact() -> Dict[str, str]:
+    phone = str(getattr(services_config, "BUSINESS_PHONE", "")).strip()
+    if not phone:
+        phone = "+1 (555) 555-1212"
+    tel_href = re.sub(r"[^0-9+]", "", phone)
+    if tel_href and not tel_href.startswith("+"):
+        tel_href = f"+{tel_href}"
+
+    address_1 = str(getattr(services_config, "BUSINESS_ADDRESS_1", "")).strip()
+    address_2 = str(getattr(services_config, "BUSINESS_ADDRESS_2", "")).strip()
+    city = str(getattr(services_config, "BUSINESS_CITY", "")).strip()
+    region = str(getattr(services_config, "BUSINESS_REGION", "")).strip()
+    postal = str(getattr(services_config, "BUSINESS_POSTAL", "")).strip()
+
+    return {
+        "name": "Petra Stock, LLC",
+        "phone": phone,
+        "phone_href": tel_href or phone,
+        "address_1": address_1 or "123 Example Street",
+        "address_2": address_2,
+        "city": city or "City",
+        "region": region or "ST",
+        "postal": postal or "00000",
+    }
 

--- a/services/config.py
+++ b/services/config.py
@@ -1,8 +1,46 @@
-"""Runtime flags for optional development helpers."""
+"""Runtime flags and environment-driven configuration helpers."""
+
 from __future__ import annotations
 
 import os
 
-DEBUG_SIMULATION: bool = os.getenv("DEBUG_SIMULATION", "0") == "1"
 
-__all__ = ["DEBUG_SIMULATION"]
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return int(default)
+    try:
+        value = int(str(raw).strip() or default)
+    except (TypeError, ValueError):
+        return int(default)
+    return value
+
+
+def _env_str(name: str, default: str) -> str:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    value = str(raw).strip()
+    return value or default
+
+
+DEBUG_SIMULATION: bool = os.getenv("DEBUG_SIMULATION", "0") == "1"
+SMS_MAX_PER_MONTH: int = max(1, _env_int("SMS_MAX_PER_MONTH", 50))
+BUSINESS_PHONE: str = _env_str("BUSINESS_PHONE", "+1 (555) 555-1212")
+BUSINESS_ADDRESS_1: str = _env_str("BUSINESS_ADDRESS_1", "123 Example Street")
+BUSINESS_ADDRESS_2: str = _env_str("BUSINESS_ADDRESS_2", "Suite 100")
+BUSINESS_CITY: str = _env_str("BUSINESS_CITY", "City")
+BUSINESS_REGION: str = _env_str("BUSINESS_REGION", "ST")
+BUSINESS_POSTAL: str = _env_str("BUSINESS_POSTAL", "00000")
+
+
+__all__ = [
+    "BUSINESS_ADDRESS_1",
+    "BUSINESS_ADDRESS_2",
+    "BUSINESS_CITY",
+    "BUSINESS_PHONE",
+    "BUSINESS_POSTAL",
+    "BUSINESS_REGION",
+    "DEBUG_SIMULATION",
+    "SMS_MAX_PER_MONTH",
+]

--- a/templates/about.html
+++ b/templates/about.html
@@ -17,9 +17,14 @@
     <p>Petra Stock is a live market pattern scanner designed for active equities traders who want timely visibility into setups that match their playbook. We monitor price, volume, and momentum data intraday, evaluate probability, and surface the opportunities that meet your custom criteria.</p>
     <p>When you enable pattern alerts, Petra Stock records your consent, verifies your phone number, and delivers informational SMS updates alongside email notifications. These alerts call out patterns we detect in the market—they are not trading advice, and you remain responsible for any decisions you make.</p>
     <p>“Pattern alerts” are short summaries of the setups you track: breakouts, reversals, consolidations, and other price structures derived from our scanner. You can adjust frequency, timing, and delivery channels directly in the Petra Stock app.</p>
+    {% set contact = business_contact() %}
     <section class="contact-block">
       <h2>Contact</h2>
-      <p>Email <a href="mailto:support@petrastock.com">support@petrastock.com</a> with any questions or to request additional information.</p>
+      <p><strong>{{ contact.name }}</strong><br />
+        {{ contact.address_1 }}{% if contact.address_2 %}, {{ contact.address_2 }}{% endif %}<br />
+        {{ contact.city }}, {{ contact.region }} {{ contact.postal }}<br />
+        <a href="tel:{{ contact.phone_href }}">{{ contact.phone }}</a> · <a href="mailto:support@petrastock.com">support@petrastock.com</a>
+      </p>
     </section>
   </article>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
   {% set canonical_path = canonical_path or (request.url.path if request else '/') %}
   {% set canonical_href = 'https://petrastock.com' + canonical_path %}
   <link rel="canonical" href="{{ canonical_href }}" />
-  <meta name="description" content="{% block meta_description %}Live pattern scanning, automated alerts, and compliance-ready SMS from Petra Stock. Message frequency varies by market activity and your settings, typically up to 10 msgs/day.{% endblock %}" />
+  <meta name="description" content="{% block meta_description %}Live pattern scanning, automated alerts, and compliance-ready SMS from Petra Stock. {{ sms_frequency_copy() }}{% endblock %}" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Petra Stock" />
   <meta property="og:url" content="{{ canonical_href }}" />
@@ -36,6 +36,7 @@
   <div class="wrap">
     {% block content %}{% endblock %}
   </div>
+  {% set contact = business_contact() %}
   <footer class="site-footer">
     <div class="footer-links">
       <a href="/sms-consent">SMS Consent</a>
@@ -45,7 +46,10 @@
       <a href="/terms">Terms of Service</a>
     </div>
     <div class="footer-meta">
-      © {{ current_year() }} Petra Stock · <a href="mailto:support@petrastock.com">support@petrastock.com</a> · <a href="https://petrastock.com">https://petrastock.com</a>
+      © {{ current_year() }} Petra Stock · <a href="mailto:support@petrastock.com">support@petrastock.com</a> · <a href="tel:{{ contact.phone_href }}">{{ contact.phone }}</a>
+    </div>
+    <div class="footer-meta">
+      {{ contact.name }} · {{ contact.address_1 }}{% if contact.address_2 %}, {{ contact.address_2 }}{% endif %}, {{ contact.city }}, {{ contact.region }} {{ contact.postal }}
     </div>
   </footer>
   {% block extra_body %}{% endblock %}

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -14,8 +14,12 @@
 {% block content %}
   <article class="marketing-page">
     <h1>Contact Us</h1>
+    {% set contact = business_contact() %}
     <p>We’re here to help with questions about Petra Stock, SMS alerts, consent records, and compliance.</p>
     <ul class="contact-list">
+      <li><strong>Company:</strong> {{ contact.name }}</li>
+      <li><strong>Address:</strong> {{ contact.address_1 }}{% if contact.address_2 %}, {{ contact.address_2 }}{% endif %}, {{ contact.city }}, {{ contact.region }} {{ contact.postal }}</li>
+      <li><strong>Phone:</strong> <a href="tel:{{ contact.phone_href }}">{{ contact.phone }}</a></li>
       <li><strong>Support:</strong> <a href="mailto:support@petrastock.com">support@petrastock.com</a></li>
       <li><strong>Privacy:</strong> <a href="mailto:privacy@petrastock.com">privacy@petrastock.com</a></li>
     </ul>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Petra Stock — Real-Time Pattern Alerts{% endblock %}
-{% block meta_description %}Petra Stock surfaces live pattern scans and automated SMS alerts so you can act on opportunities fast. Message frequency varies by market activity and your settings, typically up to 10 msgs/day.{% endblock %}
+{% block meta_description %}Petra Stock surfaces live pattern scans and automated SMS alerts so you can act on opportunities fast. {{ sms_frequency_copy() }}{% endblock %}
 {% block og_title %}Stay ahead with Petra Stock pattern alerts{% endblock %}
 {% block og_description %}Live scanner, custom SMS alerts, and compliance-ready messaging with Petra Stock. Alerts are informational only and not financial advice.{% endblock %}
 {% block body_class %}marketing{% endblock %}
@@ -20,7 +20,7 @@
       <h1>Real-time pattern alerts for active traders</h1>
       <p class="value-prop">Petra Stock continuously scans equities, highlights actionable setups, and keeps you notified with compliant SMS and email alerts.</p>
       <a class="cta-button" href="/scanner">Enter Scanner</a>
-      <p class="compliance-note">Message frequency varies by market activity and your settings, typically up to 10 msgs/day. Msg &amp; data rates may apply. Alerts are informational only and not financial advice.</p>
+      <p class="compliance-note">{{ sms_frequency_copy() }} Alerts are informational only and not financial advice.</p>
     </div>
   </section>
   <section class="features">

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -22,13 +22,19 @@
       <li>Log consent details so we can honor STOP/START/HELP keywords.</li>
       <li>Analyze aggregate usage trends to improve alert quality.</li>
     </ul>
-    <p>Message frequency varies by market activity and your settings, typically up to 10 msgs/day. Msg &amp; data rates may apply. Alerts are informational only and not financial advice.</p>
+    <p>We do not sell or share your phone number or personal information with third parties for their marketing purposes.</p>
+    <p>{{ sms_frequency_copy() }} Alerts are informational only and not financial advice.</p>
     <h2>Opt-out and deletion</h2>
     <p>Reply <strong>STOP</strong> to any Petra Stock SMS to opt out immediately. Reply <strong>HELP</strong> for assistance. You may email <a href="mailto:privacy@petrastock.com">privacy@petrastock.com</a> to request deletion of consent logs where permitted by law.</p>
     <h2>Data retention</h2>
     <p>We retain consent records for audit purposes while you are subscribed and as required to demonstrate compliance. Delivery metadata is kept for a limited period to troubleshoot issues and satisfy carrier requests.</p>
     <h2>Contact</h2>
-    <p>Questions about this policy? Email <a href="mailto:privacy@petrastock.com">privacy@petrastock.com</a> or <a href="mailto:support@petrastock.com">support@petrastock.com</a>.</p>
+    {% set contact = business_contact() %}
+    <p>Questions about this policy? Email <a href="mailto:privacy@petrastock.com">privacy@petrastock.com</a> or <a href="mailto:support@petrastock.com">support@petrastock.com</a>, or call <a href="tel:{{ contact.phone_href }}">{{ contact.phone }}</a>.</p>
+    <p><strong>{{ contact.name }}</strong><br />
+      {{ contact.address_1 }}{% if contact.address_2 %}, {{ contact.address_2 }}{% endif %}<br />
+      {{ contact.city }}, {{ contact.region }} {{ contact.postal }}
+    </p>
     <p class="footnote">Petra Stock will update this page if practices change and notify subscribers as required.</p>
   </article>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -462,6 +462,7 @@
   </div>
   <div class="card sms-card">
     <div class="card-body">
+      {% set contact = business_contact() %}
       <h2>SMS Alerts (Opt-in)</h2>
       <p id="sms-status-text" class="note sms-status {{ 'status-success' if sms_state.active else 'status-error' }}">
         {% if sms_state.active and sms_state.phone %}
@@ -473,13 +474,17 @@
       <label class="checkbox" style="gap:0.5rem; align-items:flex-start;">
         <input type="checkbox" id="sms-consent-checkbox" />
         <span id="sms-consent-copy" data-consent="{{ sms_consent_text }}">
-          I agree to receive automated Petra Stock SMS alerts. Msg &amp; data rates may apply.
-          Message frequency varies by market activity and my settings, typically up to 10 msgs/day.
-          Alerts are informational only and not financial advice. By checking this box, I agree to the
+          I agree to receive automated Petra Stock SMS alerts about pattern signals and performance updates.<br />
+          {{ sms_frequency_copy() }}<br />
+          Text STOP to opt out, HELP for help.<br />
+          By checking this box, I agree to the
           <a href="/terms" target="_blank" rel="noopener">Terms</a>
           and <a href="/privacy" target="_blank" rel="noopener">Privacy Policy</a>.
         </span>
       </label>
+      <p class="note">We do not sell or share your phone number or personal information with third parties for their marketing purposes.</p>
+      <p class="note">Alerts are informational only and not financial advice.</p>
+      <p class="note">Contact <a href="mailto:support@petrastock.com">support@petrastock.com</a> or call <a href="tel:{{ contact.phone_href }}">{{ contact.phone }}</a> with questions.</p>
       <p class="note" id="sms-unavailable-note" {% if twilio_verify_enabled %}hidden{% endif %}>
         Verification is unavailable. SMS alerts cannot be activated until Twilio verification is enabled.
       </p>

--- a/templates/sms_consent.html
+++ b/templates/sms_consent.html
@@ -12,21 +12,36 @@
   <a class="nav-link" href="/terms">Terms of Service</a>
 {% endblock %}
 {% block content %}
+  {% set contact = business_contact() %}
   <article class="marketing-page">
     <h1>SMS Alerts Opt-In</h1>
     <p>Use this form to request SMS alerts from Petra Stock if you do not have access to the in-app Settings page. We’ll send a verification code to confirm your number before enabling messages.</p>
-    <p>Message frequency varies by market activity and your settings, typically up to 10 msgs/day. Msg &amp; data rates may apply. Alerts are informational only and not financial advice.</p>
+    <p>{{ sms_frequency_copy() }} Alerts are informational only and not financial advice.</p>
+    <p>We do not sell or share your phone number or personal information with third parties for their marketing purposes.</p>
     <form class="consent-form" method="post" action="/api/sms/verify/start">
       <label for="consent-phone">Phone number (E.164, e.g., +15551234567)</label>
       <input id="consent-phone" required name="phone" type="tel" placeholder="+15551234567" />
       <label class="checkbox">
         <input required type="checkbox" name="consent" value="1" />
         <span>
-          I agree to receive automated Petra Stock SMS alerts. Msg &amp; data rates may apply. Message frequency varies by market activity and your settings, typically up to 10 msgs/day. Alerts are informational only and not financial advice. By checking this box, I agree to the <a href="/terms" target="_blank" rel="noopener">Terms</a> and <a href="/privacy" target="_blank" rel="noopener">Privacy Policy</a>.
+          I agree to receive automated Petra Stock SMS alerts about pattern signals and performance updates.<br />
+          {{ sms_frequency_copy() }}<br />
+          Text STOP to opt out, HELP for help.<br />
+          By checking this box, I agree to the <a href="/terms" target="_blank" rel="noopener">Terms</a> and <a href="/privacy" target="_blank" rel="noopener">Privacy Policy</a>.
         </span>
       </label>
-      <p class="keyword-note">Reply <strong>STOP</strong> to opt out, <strong>HELP</strong> for help. Contact <a href="mailto:support@petrastock.com">support@petrastock.com</a> with questions.</p>
+      <p class="keyword-note">Reply <strong>STOP</strong> to opt out, <strong>HELP</strong> for help.</p>
+      <p class="keyword-note">We do not sell or share your phone number or personal information with third parties for their marketing purposes.</p>
+      <p class="keyword-note">Contact <a href="mailto:support@petrastock.com">support@petrastock.com</a> or call <a href="tel:{{ contact.phone_href }}">{{ contact.phone }}</a> with questions.</p>
       <button type="submit">Send Verification Code</button>
     </form>
+    <section class="contact-block" aria-labelledby="sms-contact-heading">
+      <h2 id="sms-contact-heading">Business Contact</h2>
+      <p><strong>{{ contact.name }}</strong><br />
+        {{ contact.address_1 }}{% if contact.address_2 %}, {{ contact.address_2 }}{% endif %}<br />
+        {{ contact.city }}, {{ contact.region }} {{ contact.postal }}<br />
+        <a href="tel:{{ contact.phone_href }}">{{ contact.phone }}</a> · <a href="mailto:support@petrastock.com">support@petrastock.com</a>
+      </p>
+    </section>
   </article>
 {% endblock %}

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -16,7 +16,7 @@
     <h1>Terms of Service</h1>
     <p><strong>Effective:</strong> {{ current_year() }}</p>
     <h2>Service overview</h2>
-    <p>Petra Stock provides automated alerts about chart patterns and related market signals to subscribers who opt in. Message frequency varies by market activity and your settings, typically up to 10 msgs/day. Msg &amp; data rates may apply.</p>
+    <p>Petra Stock provides automated alerts about chart patterns and related market signals to subscribers who opt in. {{ sms_frequency_copy() }}</p>
     <h2>Opt-in and opt-out</h2>
     <p>To receive SMS alerts you must verify your phone number and agree to the SMS Consent. Reply <strong>STOP</strong> to cancel at any time. Reply <strong>START</strong> to re-enable alerts (verification may be required). Reply <strong>HELP</strong> for assistance.</p>
     <h2>Disclaimers</h2>
@@ -30,6 +30,12 @@
     <h2>Changes</h2>
     <p>We may update these Terms as our service evolves. When material changes occur we will update this page and notify active subscribers.</p>
     <h2>Contact</h2>
+    {% set contact = business_contact() %}
     <p>Email <a href="mailto:support@petrastock.com">support@petrastock.com</a> or <a href="mailto:alerts@petrastock.com">alerts@petrastock.com</a> for assistance.</p>
+    <p><strong>{{ contact.name }}</strong><br />
+      {{ contact.address_1 }}{% if contact.address_2 %}, {{ contact.address_2 }}{% endif %}<br />
+      {{ contact.city }}, {{ contact.region }} {{ contact.postal }}<br />
+      <a href="tel:{{ contact.phone_href }}">{{ contact.phone }}</a>
+    </p>
   </article>
 {% endblock %}

--- a/tests/test_public_pages.py
+++ b/tests/test_public_pages.py
@@ -1,5 +1,4 @@
 from fastapi import FastAPI
-from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
 
@@ -23,7 +22,7 @@ def test_public_pages_render(tmp_path):
     assert home.status_code == 200
     home_text = home.text
     assert "Enter Scanner" in home_text
-    assert "Message frequency varies" in home_text
+    assert "No more than" in home_text
     assert "Msg &amp; data rates may apply" in home_text or "Msg & data rates may apply" in home_text
 
     about = client.get("/about")
@@ -34,18 +33,23 @@ def test_public_pages_render(tmp_path):
     assert contact.status_code == 200
     assert "support@petrastock.com" in contact.text
     assert "privacy@petrastock.com" in contact.text
+    assert "Petra Stock, LLC" in contact.text
+    assert "+1 (555) 555-1212" in contact.text
 
     privacy = client.get("/privacy")
     assert privacy.status_code == 200
     assert "Msg &amp; data rates may apply" in privacy.text or "Msg & data rates may apply" in privacy.text
+    assert "We do not sell or share your phone number or personal information" in privacy.text
 
     terms = client.get("/terms")
     assert terms.status_code == 200
     assert "Alerts are informational only and not financial advice" in terms.text
+    assert "No more than" in terms.text
 
     consent = client.get("/sms-consent")
     assert consent.status_code == 200
     assert "Send Verification Code" in consent.text
+    assert "No more than" in consent.text
     assert "Reply <strong>STOP</strong>" in consent.text or "Reply STOP" in consent.text
 
     robots = client.get("/robots.txt")


### PR DESCRIPTION
## Summary
- Add configurable `SMS_MAX_PER_MONTH` and business contact environment settings with template helpers for shared copy
- Update opt-in, marketing, and footer templates to show the monthly SMS cap, no-sell/share statement, and business contact details inline
- Refresh public page tests to cover the revised copy and contact requirements

## Testing
- pytest tests/test_public_pages.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e3228a37788329a76085983fa4612a