### PR TITLE
Add settings_json archive support and improve favorites toggle resilience

### DIFF
--- a/alembic/versions/0010_add_settings_json_to_runs.py
+++ b/alembic/versions/0010_add_settings_json_to_runs.py
@@ -1,0 +1,50 @@
+"""Add settings_json to runs
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2024-11-19 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.dialects import postgresql
+
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = {col["name"] for col in inspector.get_columns("runs")}
+
+    if "settings_json" not in columns:
+        op.add_column(
+            "runs",
+            sa.Column(
+                "settings_json",
+                sa.JSON().with_variant(
+                    postgresql.JSONB(astext_type=sa.Text()), "postgresql"
+                ),
+                nullable=True,
+            ),
+        )
+
+    if bind.dialect.name == "postgresql":
+        with op.get_context().autocommit_block():
+            op.execute(
+                "CREATE INDEX IF NOT EXISTS ix_runs_settings_json ON runs USING GIN (settings_json)"
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        with op.get_context().autocommit_block():
+            op.execute("DROP INDEX IF EXISTS ix_runs_settings_json")
+    op.drop_column("runs", "settings_json")

--- a/models.py
+++ b/models.py
@@ -1,0 +1,28 @@
+"""SQLAlchemy ORM models used by Petra Stock services."""
+
+from __future__ import annotations
+
+from sqlalchemy import Integer, JSON, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Base declarative class for ORM models."""
+
+
+class Run(Base):
+    """Archive run metadata stored in the ``runs`` table."""
+
+    __tablename__ = "runs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    started_at: Mapped[str | None] = mapped_column(Text)
+    scan_type: Mapped[str | None] = mapped_column(Text)
+    params_json: Mapped[str | None] = mapped_column(Text)
+    universe: Mapped[str | None] = mapped_column(Text)
+    finished_at: Mapped[str | None] = mapped_column(Text)
+    hit_count: Mapped[int | None] = mapped_column(Integer)
+    settings_json: Mapped[dict | None] = mapped_column(
+        JSON().with_variant(JSONB(astext_type=Text()), "postgresql"), nullable=True
+    )

--- a/templates/partials/fav_star.html
+++ b/templates/partials/fav_star.html
@@ -1,0 +1,19 @@
+{% set active = is_favorite if is_favorite is not none else False %}
+{% set label = 'Remove from favorites' if active else 'Add to favorites' %}
+<button
+  type="button"
+  class="btn-fav{% if active %} is-active{% endif %}"
+  hx-post="/favorites/toggle"
+  hx-target="this"
+  hx-swap="outerHTML"
+  data-ticker="{{ ticker }}"
+  data-direction="{{ direction }}"
+  data-interval="{{ interval }}"
+  data-rule="{{ rule }}"
+  {% if favorite_id is not none %}data-favorite-id="{{ favorite_id }}"{% endif %}
+  aria-pressed="{{ 'true' if active else 'false' }}"
+  aria-label="{{ label }}"
+  title="{{ label }}"
+>
+  {% if active %}⭐{% else %}☆{% endif %}
+</button>


### PR DESCRIPTION
## Summary
- add Alembic migration 0010 to backfill the runs.settings_json column and ensure a Postgres JSONB index exists
- introduce an ORM Run model with a nullable settings_json mapping column for future use
- normalize archive save handlers to prefer the new settings payload, with helpers for parsing and serialization
- extract shared favorite payload handling, add a robust /favorites/toggle endpoint, and return an HTMX-friendly star partial
- improve the scanner favorites JS to surface server errors from responses and HTMX events

## Testing
- `pytest` *(fails: tests/test_data_provider.py::test_fetch_bars_uses_schwab, tests/test_data_provider.py::test_fetch_bars_fallbacks_to_yfinance)*

------
https://chatgpt.com/codex/tasks/task_e_68e32fa8e684832999c0013451d6428d